### PR TITLE
Generate enrollment pings and add test coverage

### DIFF
--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -57,6 +57,11 @@ module.exports = class IonCore {
         // is expecting it.
         return this._enroll().then(r => true);
       } break;
+      case "study-enrollment": {
+        // Let's not forget to respond `true` to the sender: the UI
+        // is expecting it.
+        return this._enrollStudy(message.data.studyID).then(r => true);
+      } break;
       default:
         console.error(`IonCore - unexpected message type ${message.type}`);
         return Promise.reject();
@@ -87,6 +92,21 @@ module.exports = class IonCore {
 
     // Finally send the ping.
     await this._sendEnrollmentPing();
+  }
+
+  /**
+   * Enroll in an Ion Study.
+   *
+   * This sends the required pings,
+   *
+   * @returns {Promise} A promise resolved when the enrollment
+   *          is complete (does not block on data upload).
+   */
+  async _enrollStudy(studyAddonId) {
+    // TODO: Validate the study id?
+
+    // Finally send the ping.
+    await this._sendEnrollmentPing(studyAddonId);
   }
 
   /**

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -42,13 +42,11 @@ module.exports = class IonCore {
    *          `sender`.
    */
   _handleMessage(message, sender) {
-    console.log(`IonCore - received message ${message} from ${sender}`);
-
     // We only expect messages coming from the embedded options page
     // at this time. Discard anything else and report an error.
     if (sender.url != browser.runtime.getURL(ION_OPTIONS_PAGE_PATH)) {
-      console.error(`IonCore - received message from unexpected sender`);
-      return Promise.reject();
+      return Promise.reject(
+        new Error("IonCore - received message from unexpected sender"));
     }
 
     switch (message.type) {
@@ -63,8 +61,8 @@ module.exports = class IonCore {
         return this._enrollStudy(message.data.studyID).then(r => true);
       } break;
       default:
-        console.error(`IonCore - unexpected message type ${message.type}`);
-        return Promise.reject();
+        return Promise.reject(
+          new Error(`IonCore - unexpected message type ${message.type}`));
     }
   }
 

--- a/core-addon/telemetry/LegacyTelemetryApi.js
+++ b/core-addon/telemetry/LegacyTelemetryApi.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const { TelemetryController } = ChromeUtils.import(
+  "resource://gre/modules/TelemetryController.jsm"
+);
+
+// The pref that contains the Ion ID within Firefox. Unfortunately
+// the telemetry APIs require this, therefore it needs to be set in
+// prefs even though it will be stored in the standard addon storage area.
+const PREF_ION_ID = "toolkit.telemetry.pioneerId";
+
+this.legacyTelemetryApi = class extends ExtensionAPI {
+  getAPI(context) {
+    var self = this;
+    return {
+      legacyTelemetryApi: {
+        async submitEncryptedPing(type, payload, options) {
+          console.debug(`Ion - Sending ping through legacy telemetry (${type})`);
+
+          // This function will always send encrypted pings.
+          let augmentedOptions = options;
+          augmentedOptions.useEncryption = true;
+
+          TelemetryController.submitExternalPing(type, payload, options);
+        },
+        async setIonID(id) {
+          Services.prefs.setStringPref(PREF_ION_ID, id);
+        },
+        async clearIonID() {
+          Services.prefs.clearUserPref(PREF_ION_ID);
+        }
+      }
+    }
+  }
+};

--- a/core-addon/telemetry/LegacyTelemetryApi.js
+++ b/core-addon/telemetry/LegacyTelemetryApi.js
@@ -8,6 +8,13 @@ const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const { TelemetryController } = ChromeUtils.import(
   "resource://gre/modules/TelemetryController.jsm"
 );
+const { XPCOMUtils } = ChromeUtils.import(
+  "resource://gre/modules/XPCOMUtils.jsm"
+);
+
+XPCOMUtils.defineLazyServiceGetters(this, {
+  gUUIDGenerator: ["@mozilla.org/uuid-generator;1", "nsIUUIDGenerator"],
+});
 
 // The pref that contains the Ion ID within Firefox. Unfortunately
 // the telemetry APIs require this, therefore it needs to be set in
@@ -33,6 +40,10 @@ this.legacyTelemetryApi = class extends ExtensionAPI {
         },
         async clearIonID() {
           Services.prefs.clearUserPref(PREF_ION_ID);
+        },
+        async generateUUID() {
+          let str = gUUIDGenerator.generateUUID().toString();
+          return str.substring(1, str.length - 1);
         }
       }
     }

--- a/core-addon/telemetry/LegacyTelemetryApi.schema.json
+++ b/core-addon/telemetry/LegacyTelemetryApi.schema.json
@@ -73,6 +73,13 @@
         "description": "Clears the Ion ID stored in the Firefox prefs",
         "parameters": [],
         "async": true
+      },
+      {
+        "name": "generateUUID",
+        "type": "function",
+        "description": "Generate a random UUID using the Firefox APIs",
+        "parameters": [],
+        "async": true
       }
     ]
   }

--- a/core-addon/telemetry/LegacyTelemetryApi.schema.json
+++ b/core-addon/telemetry/LegacyTelemetryApi.schema.json
@@ -1,0 +1,79 @@
+[
+  {
+    "namespace": "legacyTelemetryApi",
+    "description": "experimental API extensions submit legacy telemetry",
+    "functions": [
+      {
+        "name": "submitEncryptedPing",
+        "type": "function",
+        "description": "Submits an encrypted ping using Legacy Telemetry in Firefox",
+        "parameters": [
+          {
+            "name": "type",
+            "type": "string"
+          },
+          {
+            "name": "payload",
+            "$ref": "extensionTypes.PlainJSONValue",
+            "description": "The payload of the legacy telemetry ping."
+          },
+          {
+            "name": "options",
+            "type": "object",
+            "properties": {
+              "studyName": {
+                "type": "string",
+                "description": "The study name to use"
+              },
+              "addPioneerId": {
+                "type": "boolean",
+                "description": "Whether or not the ping should contain the Pioneer ID"
+              },
+              "encryptionKeyId": {
+                "type": "string",
+                "description": "The public key ID to use"
+              },
+              "publicKey": {
+                "type": "object",
+                "description": "The public key to use (JSON Web Key)",
+                "additionalProperties": { "type": "any" }
+              },
+              "schemaName": {
+                "type": "string",
+                "description": "The schema name to use"
+              },
+              "schemaNamespace": {
+                "type": "string",
+                "description": "The schema namespace to use"
+              },
+              "schemaVersion": {
+                "type": "number",
+                "description": "The schema version to use"
+              }
+            }
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "setIonID",
+        "type": "function",
+        "description": "Saves the Ion ID in the Firefox prefs",
+        "parameters": [
+          {
+            "name": "type",
+            "type": "string"
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "clearIonID",
+        "type": "function",
+        "description": "Clears the Ion ID stored in the Firefox prefs",
+        "parameters": [],
+        "async": true
+      }
+    ]
+  }
+]

--- a/manifest.json
+++ b/manifest.json
@@ -48,5 +48,17 @@
   "options_ui": {
     "page": "public/index.html",
     "open_in_tab": true
+  },
+
+  "experiment_apis": {
+    "legacyTelemetryApi": {
+      "schema": "core-addon/telemetry/LegacyTelemetryApi.schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "core-addon/telemetry/LegacyTelemetryApi.js",
+        "events": [],
+        "paths": [["legacyTelemetryApi"]]
+      }
+    }
   }
 }

--- a/src/StudyCard.svelte
+++ b/src/StudyCard.svelte
@@ -10,7 +10,8 @@
 
   const dispatch = createEventDispatcher();
   function toggleStudy() {
-    dispatch("enroll", studyId);
+    // Bubble up the "enroll" event to the `StudyList` component.
+    dispatch("enroll", {studyId: studyId, enroll: !studyEnrolled});
     // if (studyEnrolled) {
     //   dispatchFxEvent({ uninstallStudy: studyId });
     // } else {

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -93,16 +93,12 @@ export default {
 
   /**
    * Updates the overall Ion enrollment in the add-on.
-   * NOTE: if updating in the app store in the add-on suffices,
-   * this should probably just return the OK signal.
    *
    * @param {Boolean} enroll
    *        `true` if user decided to enroll in the Ion platform,
    *        `false` otherwise.
-   * TODO: Why can `enroll` be undefined?
    */
   async updateIonEnrollment(enroll) {
-    let coercedEnroll = !!enroll;
-    return await sendToCore("enrollment", {});
+    return await sendToCore(enroll ? "enrollment" : "unenrollment", {});
   },
 };

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -16,6 +16,7 @@
 async function sendToCore(type, payload) {
   const VALID_TYPES = [
     "enrollment",
+    "study-enrollment",
   ];
 
   // Make sure `type` is one of the expected values.
@@ -84,11 +85,19 @@ export default {
     return browser.storage.local.set({ [key]: value });
   },
 
-  // updates the study enrollment in the add-on, if needed.
-  // NOTE: if updating in the app store in the add-on suffices,
-  // this should probably just return the OK signal.
+  /**
+   * Updates the study enrollment.
+   *
+   * @param {Boolean} enroll
+   *        `true` if user decided to enroll in an Ion Study,
+   *        `false` if user opted out.
+   */
+
   async updateStudyEnrollment(studyID, enroll) {
-    return true;
+    const msg = enroll ? "study-enrollment" : "study-unenrollment";
+    return await sendToCore(msg, {
+      studyID
+    });
   },
 
   /**

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -1,9 +1,42 @@
-/* 
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-This API implementation depends on sending messages back to 
-a web extension to store the overall app state whenever it changes.
+/**
+ * Utility function to build a message to the web-extension.
+ *
+ * @param {String} type
+ *        The type of the message being sent. Unknown types
+ *        will be rejected by the Core Add-on. Valid values
+ *        are: `enrollment` (to enroll in Ion).
+ * @param {Object} payload
+ *        A JSON-serializable object representing the payload
+ *        of the message to be passed to the Core addon.
+ */
+async function sendToCore(type, payload) {
+  const VALID_TYPES = [
+    "enrollment",
+  ];
 
-*/
+  // Make sure `type` is one of the expected values.
+  if (!VALID_TYPES.includes(type)) {
+    console.error(`Ion: sendToCore - unexpected message to core "${type}"`);
+    return Promise.reject();
+  }
+
+  const msg = {
+    type,
+    data: payload
+  };
+
+  return await browser.runtime.sendMessage(msg);
+}
+
+/**
+ * This API implementation depends on sending messages back to
+ * a web extension to store the overall app state whenever it
+ * changes.
+ */
 export default {
   // initialize the frontend's store from the add-on local storage.
   async initialize(key) {
@@ -58,10 +91,18 @@ export default {
     return true;
   },
 
-  // updates the overall Ion enrollment in the add-on, if needed.
-  // NOTE: if updating in the app store in the add-on suffices,
-  // this should probably just return the OK signal.
-  async updateIonEnrollment(studyID, enroll) {
-    return true;
+  /**
+   * Updates the overall Ion enrollment in the add-on.
+   * NOTE: if updating in the app store in the add-on suffices,
+   * this should probably just return the OK signal.
+   *
+   * @param {Boolean} enroll
+   *        `true` if user decided to enroll in the Ion platform,
+   *        `false` otherwise.
+   * TODO: Why can `enroll` be undefined?
+   */
+  async updateIonEnrollment(enroll) {
+    let coercedEnroll = !!enroll;
+    return await sendToCore("enrollment", {});
   },
 };

--- a/src/create-store.js
+++ b/src/create-store.js
@@ -28,11 +28,17 @@ export default function createStore(initialState, api) {
         state[key] = value;
       });
     },
-    async updateStudyEnrollment(studyID, enroll = undefined) {
+    async updateStudyEnrollment(studyID, enroll) {
+      // Enforce the truthyness of `enroll`, to make sure
+      // it's always a boolean.
+      let coercedEnroll = !!enroll;
+      console.debug(
+        `Ion - changing study ${studyID} enrollment to ${coercedEnroll}`);
+
       let outcome;
       // send study enrollment message
       try {
-        outcome = await api.updateStudyEnrollment(studyID, enroll);
+        outcome = await api.updateStudyEnrollment(studyID, coercedEnroll);
       } catch (err) {
         console.error(err);
       }

--- a/src/create-store.js
+++ b/src/create-store.js
@@ -49,18 +49,23 @@ export default function createStore(initialState, api) {
         });
       }
     },
-    async updateIonEnrollment(enroll = undefined) {
+    async updateIonEnrollment(enroll) {
+      // Enforce the truthyness of `enroll`, to make sure
+      // it's always a boolean.
+      let coercedEnroll = !!enroll;
+      console.debug(`Ion - changing enrollment to ${coercedEnroll}`);
+
       let outcome;
       // send the ion enrollment message
       try {
-        outcome = await api.updateIonEnrollment(enroll);
+        outcome = await api.updateIonEnrollment(coercedEnroll);
       } catch (err) {
         console.log(err);
       }
       // if ion enrollment is successful, update frontend.
       if (outcome) {
         this.produce((draft) => {
-          draft.enrolled = enroll === undefined ? !draft.enrolled : enroll;
+          draft.enrolled = coercedEnroll;
         });
       }
     },

--- a/src/regions/StudyList.svelte
+++ b/src/regions/StudyList.svelte
@@ -20,7 +20,16 @@
       studyId={study.addon_id}
       enrolled={$store.enrolled}
       studyEnrolled={$store.activeStudies.includes(study.addon_id)}
-      on:enroll={() => store.updateStudyEnrollment(study.addon_id)}>
+      on:enroll={(e) => {
+        const eventData = e.detail;
+        if (!eventData
+          || typeof eventData != "object"
+          || !eventData.studyId) {
+          console.error("Invalid enrollment event data");
+          return;
+        }
+        store.updateStudyEnrollment(eventData.studyId, eventData.enroll);
+      }}>
       <span slot="name">{study.name}</span>
       <span slot="authors">{study.authors.name}</span>
       <span slot="description">{study.description}</span>

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -3,11 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var assert = require('assert');
+var sinon = require('sinon');
 
 var IonCore = require('../../core-addon/IonCore');
 
 describe('IonCore', function () {
-  before(function () {
+  beforeEach(function () {
     this.ionCore = new IonCore();
   });
 
@@ -19,7 +20,138 @@ describe('IonCore', function () {
     });
   });
 
-  after(function () {
+  describe('initialize()', function () {
+    it('opens the options page on install', function () {
+      chrome.runtime.openOptionsPage.flush();
+      // The initializer installs the handlers.
+      this.ionCore.initialize();
+      // Dispatch an installation event to see if the page is
+      // opened.
+      chrome.runtime.onInstalled.dispatch({reason: "install"});
+      assert.ok(chrome.runtime.openOptionsPage.calledOnce);
+    });
+
+    it('listens for clicks and messages', function () {
+      this.ionCore.initialize();
+      assert.ok(chrome.browserAction.onClicked.addListener.calledOnce);
+      assert.ok(chrome.runtime.onMessage.addListener.calledOnce);
+    });
+  });
+
+  describe('_handleMessage()', function () {
+    it('rejects unknown messages', function () {
+      // Mock the URL of the options page.
+      const TEST_OPTIONS_URL = "install.sample.html";
+      chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
+
+      // Provide an unknown message type and a valid origin:
+      // it should fail due to the unexpected type.
+      assert.rejects(
+        this.ionCore._handleMessage(
+          {type: "test-unknown-type", data: {}},
+          {url: TEST_OPTIONS_URL}
+        ),
+        { message: "IonCore - unexpected message type test-unknown-type"}
+      );
+    });
+
+    it('rejects unknown senders', function () {
+      // Mock the URL of the options page.
+      const TEST_OPTIONS_URL = "install.sample.html";
+      chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
+
+      // Provide an unknown message type and a valid origin:
+      // it should fail due to the unexpected type.
+      assert.rejects(
+        this.ionCore._handleMessage(
+          {type: "enroll", data: {}},
+          {url: "unkown-sender-url.html"}
+        ),
+        { message: "IonCore - received message from unexpected sender"}
+      );
+    });
+
+    it('dispatchers enrollment messages', async function () {
+      // Mock the URL of the options page.
+      const TEST_OPTIONS_URL = "install.sample.html";
+      chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
+
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.legacyTelemetryApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+      let telemetryMock = sinon.mock(chrome.legacyTelemetryApi);
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.legacyTelemetryApi, "submitEncryptedPing");
+      // Make sure to mock the local storage calls as well.
+      chrome.storage.local.set.yields();
+
+      // Provide a valid enrollment message.
+      await this.ionCore._handleMessage(
+        {type: "enrollment", data: {}},
+        {url: TEST_OPTIONS_URL}
+      );
+
+      // We expect to store the fake ion ID...
+      telemetryMock.expects("setIonID").withArgs([FAKE_UUID]).calledOnce;
+      // ... to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... an empty payload ...
+      assert.equal(Object.keys(submitArgs[1]).length, 0);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, "pioneer-meta");
+      assert.equal(submitArgs[2].encryptionKeyId, "discarded");
+      assert.equal(submitArgs[2].schemaName, "pioneer-enrollment");
+      assert.equal(submitArgs[2].schemaNamespace, "pioneer-meta");
+    });
+
+    it('dispatchers study-enrollment messages', async function () {
+      // Mock the URL of the options page.
+      const TEST_OPTIONS_URL = "install.sample.html";
+      chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
+
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.legacyTelemetryApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+      let telemetryMock = sinon.mock(chrome.legacyTelemetryApi);
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.legacyTelemetryApi, "submitEncryptedPing");
+      // Make sure to mock the local storage calls as well.
+      chrome.storage.local.set.yields();
+
+      // Provide a valid study enrollment message.
+      const FAKE_STUDY_ID = "test@ion-studies.com";
+      await this.ionCore._handleMessage(
+        {type: "study-enrollment", data: { studyID: FAKE_STUDY_ID}},
+        {url: TEST_OPTIONS_URL}
+      );
+
+      // We expect to store the fake ion ID...
+      telemetryMock.expects("setIonID").withArgs([FAKE_UUID]).calledOnce;
+      // ... to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... an empty payload ...
+      assert.equal(Object.keys(submitArgs[1]).length, 0);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, FAKE_STUDY_ID);
+      assert.equal(submitArgs[2].encryptionKeyId, "discarded");
+      assert.equal(submitArgs[2].schemaName, "pioneer-enrollment");
+      assert.equal(submitArgs[2].schemaNamespace, FAKE_STUDY_ID);
+    });
+  });
+
+  afterEach(function () {
     chrome.flush();
   });
 });

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -110,7 +110,7 @@ describe('IonCore', function () {
       assert.equal(submitArgs[2].schemaNamespace, "pioneer-meta");
     });
 
-    it('dispatchers study-enrollment messages', async function () {
+    it('dispatches study-enrollment messages', async function () {
       // Mock the URL of the options page.
       const TEST_OPTIONS_URL = "install.sample.html";
       chrome.runtime.getURL.returns(TEST_OPTIONS_URL);


### PR DESCRIPTION
Fixes #13.

This came out to be a big bigger than I initially expected! Unfortunately the legacy telemetry APIs exposed to addons make a few assumptions (e.g. study name lives in the manifest). These assumptions do not hold true anymore as we move towards the new architecture. To work around this, I added an "experimental" API that exposes a custom legacy telemetry API to the addon.

See the individual commits for more information.

TODO (the deletion ping will be added as a separate PR):

- [x] Unit tests;
- [x] Study enrollment (we only have platform enrollment)