### PR TITLE
document building from a clean repo to a generated add-on artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ To run a local webserver (`http://localhost:5000`) for the UI which auto-reloads
 npm run dev
 ```
 
+# Build the Core addon
+
 When ready, package up for use inside the web extension:
 
 ```bash
 npm run build
 ```
 
-# Build the Core addon
-With the UI is generated, the addon can finally be built:
+Build the local version of the addon:
 
 ```bash
 npm run build-addon

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ When ready, package up for use inside the web extension:
 npm run build
 ```
 
+# Build the Core addon
+With the UI is generated, the addon can finally be built:
+
+```bash
+npm run build-addon
+```
+
 ...then start [web-ext](https://github.com/mozilla/web-ext):
 
 ```bash
@@ -41,15 +48,16 @@ web-ext run
 web-ext run -t chromium
 ```
 
-# Build the Core addon
-With the UI is generated, the addon can finally be built:
-
-```bash
-npm run build-addon
-```
-
 To run test coverage:
 
 ```bash
 npm run test-addon
 ```
+
+To generate an installable extension file:
+
+```bash
+web-ext build
+```
+
+The output will be a `.zip` file in `web-ext-artifacts/` - this should be renamed to `.xpi` for Firefox and `.crx` for Chrome.


### PR DESCRIPTION
I noticed that the current instructions don't work on a clean checkout (`npm run build-addon` must be run before `web-ext`). @hamilton and I discussed and the real fix here is to simplify these build targets, but for the moment I think having them work out-of-the-box is good enough.

I've also added instructions on how to generate an add-on file and what to do with it.

These are the instructions I used to generate the 0.1 release .xpi