### PR TITLE
Send the deletion pings for all the studies user was enrolled in

### DIFF
--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -2,10 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const Storage = require("./Storage.js");
+
 // The path of the embedded resource used to control Ion options.
 const ION_OPTIONS_PAGE_PATH = "public/index.html";
 
 module.exports = class IonCore {
+  constructor() {
+    this._storage = new Storage();
+  }
+
   initialize() {
     // Whenever the addon icon is clicked, open the control page.
     browser.browserAction.onClicked.addListener(this._openControlPanel);
@@ -80,7 +86,7 @@ module.exports = class IonCore {
     const uuid = await browser.legacyTelemetryApi.generateUUID();
 
     // Store it locally for future use.
-    await browser.storage.local.set({ionId: uuid});
+    await this._storage.setIonID(uuid);
 
     // The telemetry API, before sending a ping, reads the
     // ion id from a pref. It no value is set, the API will
@@ -102,6 +108,9 @@ module.exports = class IonCore {
    */
   async _enrollStudy(studyAddonId) {
     // TODO: Validate the study id?
+
+    // Record that user activated this study.
+    await this._storage.appendActivatedStudy(studyAddonId);
 
     // Finally send the ping.
     await this._sendEnrollmentPing(studyAddonId);

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -186,4 +186,18 @@ module.exports = class IonCore {
     // a specific study), use a meta namespace.
     return await this._sendEmptyPing("pioneer-enrollment", "pioneer-meta");
   }
+
+  /**
+   * Sends a Ion deletion-request ping.
+   *
+   * @param {String} studyAddonid
+   *        It's sent in the ping to signal that user unenroled from a study.
+   */
+  async _sendDeletionPing(studyAddonId) {
+    if (typeof studyAddonId == "undefined") {
+      throw new Error("IonCore - the deletion-request ping requires a study id");
+    }
+
+    return await this._sendEmptyPing("deletion-request", studyAddonId);
+  }
 }

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -233,10 +233,10 @@ module.exports = class IonCore {
    * Sends a Ion deletion-request ping.
    *
    * @param {String} studyAddonid
-   *        It's sent in the ping to signal that user unenroled from a study.
+   *        It's sent in the ping to signal that user unenrolled from a study.
    */
   async _sendDeletionPing(studyAddonId) {
-    if (typeof studyAddonId == "undefined") {
+    if (typeof studyAddonId === undefined) {
       throw new Error("IonCore - the deletion-request ping requires a study id");
     }
 

--- a/core-addon/Storage.js
+++ b/core-addon/Storage.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = class Storage {
+  async setIonID(uuid) {
+    return await browser.storage.local.set({ionId: uuid});
+  }
+
+  async clearIonID() {
+    return await browser.storage.local.remove("ionId");
+  }
+
+  /**
+   * Adds a study id to the stored list of activated studies.
+   *
+   * @param {String} studyId
+   *        The id of the study to add to the list. If the id
+   *        is already present, this function is a no-op.
+   * @returns {Promise} resolved with the list of activated studies
+   *          if the study is added to the list, rejected on errors.
+   */
+  async appendActivatedStudy(studyId) {
+    // Attempt to retrieve any previously stored study ids.
+    let storedIds = await browser.storage.local.get("activatedStudies").then(
+        stored => {
+          // This branch will be hit even if `activatedStudies` was never
+          // stored (e.g. this is the first save). Make sure to account for
+          // that case by returning an empty array.
+          return stored.activatedStudies || [];
+        },
+        error => {
+          console.error("Storage - failed to read from the local storage", error);
+          return [];
+        }
+      );
+
+    // If the study id is already present bail out.
+    if (storedIds.includes(studyId)) {
+      return storedIds;
+    }
+
+    storedIds.push(studyId);
+
+    // Store the updated list.
+    await browser.storage.local.set({activatedStudies: storedIds});
+
+    return storedIds;
+  }
+};

--- a/core-addon/Storage.js
+++ b/core-addon/Storage.js
@@ -12,17 +12,14 @@ module.exports = class Storage {
   }
 
   /**
-   * Adds a study id to the stored list of activated studies.
+   * Get the list of study ids user took part to.
    *
-   * @param {String} studyId
-   *        The id of the study to add to the list. If the id
-   *        is already present, this function is a no-op.
    * @returns {Promise} resolved with the list of activated studies
    *          if the study is added to the list, rejected on errors.
    */
-  async appendActivatedStudy(studyId) {
+  async getActivatedStudies() {
     // Attempt to retrieve any previously stored study ids.
-    let storedIds = await browser.storage.local.get("activatedStudies").then(
+    return await browser.storage.local.get("activatedStudies").then(
         stored => {
           // This branch will be hit even if `activatedStudies` was never
           // stored (e.g. this is the first save). Make sure to account for
@@ -34,6 +31,20 @@ module.exports = class Storage {
           return [];
         }
       );
+  }
+
+  /**
+   * Adds a study id to the stored list of activated studies.
+   *
+   * @param {String} studyId
+   *        The id of the study to add to the list. If the id
+   *        is already present, this function is a no-op.
+   * @returns {Promise} resolved with the list of activated studies
+   *          if the study is added to the list, rejected on errors.
+   */
+  async appendActivatedStudy(studyId) {
+    // Attempt to retrieve any previously stored study ids.
+    let storedIds = await this.getActivatedStudies();
 
     // If the study id is already present bail out.
     if (storedIds.includes(studyId)) {
@@ -46,5 +57,9 @@ module.exports = class Storage {
     await browser.storage.local.set({activatedStudies: storedIds});
 
     return storedIds;
+  }
+
+  async clearActivatedStudies() {
+    return await browser.storage.local.remove("activatedStudies");
   }
 };

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -17,6 +17,7 @@ async function sendToCore(type, payload) {
   const VALID_TYPES = [
     "enrollment",
     "study-enrollment",
+    "unenrollment",
   ];
 
   // Make sure `type` is one of the expected values.

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -154,6 +154,54 @@ describe('IonCore', function () {
       assert.equal(submitArgs[2].schemaName, "pioneer-enrollment");
       assert.equal(submitArgs[2].schemaNamespace, FAKE_STUDY_ID);
     });
+
+    it('dispatches unenrollment messages', async function () {
+      // Mock the URL of the options page.
+      const TEST_OPTIONS_URL = "install.sample.html";
+      chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
+
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.legacyTelemetryApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        clearIonID: async function() {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+      let telemetryMock = sinon.mock(chrome.legacyTelemetryApi);
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.legacyTelemetryApi, "submitEncryptedPing");
+
+      // Return an empty object from the local storage. Note that this
+      // needs to use `browser` and must use `callsArgWith` to guarantee
+      // that the promise resolves, due to a bug in sinon-chrome. See
+      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
+      const FAKE_STUDY_ID = "test@ion-studies.com";
+      browser.storage.local.get
+        .callsArgWith(1, {activatedStudies: [FAKE_STUDY_ID]})
+        .resolves();
+      browser.storage.local.remove.yields();
+
+      // Provide a valid study enrollment message.
+      await this.ionCore._handleMessage(
+        {type: "unenrollment", data: {}},
+        {url: TEST_OPTIONS_URL}
+      );
+
+      // We expect to store the fake ion ID...
+      telemetryMock.expects("clearIonID").calledOnce;
+      // ... to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... an empty payload ...
+      assert.equal(Object.keys(submitArgs[1]).length, 0);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, FAKE_STUDY_ID);
+      assert.equal(submitArgs[2].encryptionKeyId, "discarded");
+      assert.equal(submitArgs[2].schemaName, "deletion-request");
+      assert.equal(submitArgs[2].schemaNamespace, FAKE_STUDY_ID);
+    });
   });
 
   afterEach(function () {

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -126,8 +126,13 @@ describe('IonCore', function () {
       // Use the spy to record the arguments of submitEncryptedPing.
       let telemetrySpy =
         sinon.spy(chrome.legacyTelemetryApi, "submitEncryptedPing");
-      // Make sure to mock the local storage calls as well.
-      chrome.storage.local.set.yields();
+
+      // Return an empty object from the local storage. Note that this
+      // needs to use `browser` and must use `callsArgWith` to guarantee
+      // that the promise resolves, due to a bug in sinon-chrome. See
+      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
+      browser.storage.local.get.callsArgWith(1, {}).resolves();
+      chrome.storage.local.get.yields({});
 
       // Provide a valid study enrollment message.
       const FAKE_STUDY_ID = "test@ion-studies.com";

--- a/tests/core-addon/Storage.test.js
+++ b/tests/core-addon/Storage.test.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var assert = require('assert');
+var sinon = require('sinon');
+
+var Storage = require('../../core-addon/Storage');
+
+describe('Storage', function () {
+  beforeEach(function () {
+    this.storage = new Storage();
+  });
+
+  describe('appendActivatedStudy()', async function () {
+    it('should correctly append studies on first run', async function () {
+      const TEST_ADDON_ID = "test-id@ion.com";
+      // Return an empty object from the local storage. Note that this
+      // needs to use `browser` and must use `callsArgWith` to guarantee
+      // that the promise resolves, due to a bug in sinon-chrome. See
+      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
+      browser.storage.local.get.callsArgWith(1, {}).resolves();
+
+      let storedIds = await this.storage.appendActivatedStudy(TEST_ADDON_ID);
+
+      assert.equal(storedIds.length, 1);
+      assert.ok(storedIds.includes(TEST_ADDON_ID));
+    });
+
+    it('should correctly append on read errors', async function () {
+      const TEST_ADDON_ID = "test-id@ion.com";
+      // Return an empty object from the local storage. Note that this
+      // needs to use `browser` and must use `callsArgWith` to guarantee
+      // that the promise resolves, due to a bug in sinon-chrome. See
+      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
+      browser.storage.local.get.callsArgWith(1, {}).throws();
+
+      let storedIds = await this.storage.appendActivatedStudy(TEST_ADDON_ID);
+
+      assert.equal(storedIds.length, 1);
+      assert.ok(storedIds.includes(TEST_ADDON_ID));
+    });
+
+    it('should append the same id only once', async function () {
+      const TEST_ADDON_ID = "test-id@ion.com";
+      // Return an empty object from the local storage. Note that this
+      // needs to use `browser` and must use `callsArgWith` to guarantee
+      // that the promise resolves, due to a bug in sinon-chrome. See
+      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
+      browser.storage.local.get
+        .callsArgWith(1, {activatedStudies: [TEST_ADDON_ID]})
+        .resolves();
+
+      let storedIds = await this.storage.appendActivatedStudy(TEST_ADDON_ID);
+
+      assert.equal(storedIds.length, 1);
+      assert.ok(storedIds.includes(TEST_ADDON_ID));
+    });
+  });
+
+  afterEach(function () {
+    chrome.flush();
+  });
+});


### PR DESCRIPTION
Fixes #23

This PR changes a few things::

- it refactors the code to send empty pings, to share it between enrollment and deletion;
- it abstracts away the code to interact with the local storage;