### PR TITLE
Add installation state to `_availableStudies`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
   },
 
   "permissions": [
+    "management",
     "telemetry",
     "storage",
     "https://firefox.settings.services.mozilla.com/"

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -11,17 +11,35 @@ describe('IonCore', function () {
   // A fake study id to use in the tests when looking for a
   // "known" study.
   FAKE_STUDY_ID = "test@ion-studies.com";
+  FAKE_STUDY_ID_NOT_INSTALLED = "test-not-installed@ion-studies.com";
+  FAKE_STUDY_LIST = [
+    {
+      "addon_id": FAKE_STUDY_ID
+    },
+    {
+      "addon_id": FAKE_STUDY_ID_NOT_INSTALLED
+    }
+  ];
 
   beforeEach(function () {
+    // Force the sinon-chrome stubbed API to resolve its promise
+    // in tests. Without the next two lines, tests querying the
+    // `browser.management.getAll` API will be stuck and timeout.
+    // Note that this will fake our data to make FAKE_STUDY_ID look
+    // installed.
+    chrome.management.getAll
+      .callsArgWith(0, [{type: "extension", id: FAKE_STUDY_ID}])
+      .resolves();
+    chrome.management.getAll.yields(
+      [{type: "extension", id: FAKE_STUDY_ID}]);
+
     // NodeJS doesn't support "fetch" so we need to mock it
     // manually (or use a third party package). This isn't too
-    // bad, as we can just return our `FAKE_STUDY_ID`.
+    // bad, as we can just return our fake ids.
     global.fetch = () => Promise.resolve({
       json() {
         return {
-          "data": [{
-            "addon_id": FAKE_STUDY_ID
-          }]
+          "data": FAKE_STUDY_LIST
         }
       }
     });
@@ -52,6 +70,12 @@ describe('IonCore', function () {
       this.ionCore.initialize();
       assert.ok(chrome.browserAction.onClicked.addListener.calledOnce);
       assert.ok(chrome.runtime.onMessage.addListener.calledOnce);
+    });
+
+    it('listens for addon state changes', function () {
+      this.ionCore.initialize();
+      assert.ok(chrome.management.onInstalled.addListener.calledOnce);
+      assert.ok(chrome.management.onUninstalled.addListener.calledOnce);
     });
   });
 
@@ -225,6 +249,45 @@ describe('IonCore', function () {
         this.ionCore._enrollStudy("unknown-test-study-id@ion.com"),
         { message: "IonCore._enrollStudy - Unknown study unknown-test-study-id@ion.com"}
       );
+    });
+  });
+
+  describe('_fetchAvailableStudies()', function () {
+    it('returns a list of addons', async function () {
+      let studies = await this.ionCore._fetchAvailableStudies();
+      assert.equal(studies.length, 2);
+      assert.ok(studies.filter(a => (a.addon_id === FAKE_STUDY_ID)));
+      assert.ok(studies.filter(a => (a.addon_id === FAKE_STUDY_ID_NOT_INSTALLED)));
+    });
+
+    it('returns an empty list on errors', async function () {
+      // Mock the 'fetch' to reject.
+      global.fetch = () => Promise.reject();
+      let studies = await this.ionCore._fetchAvailableStudies();
+      assert.equal(studies.length, 0);
+    });
+  });
+
+  describe('runUpdateInstalledStudiesTask()', function () {
+    it('adds the ionInstalled property', async function () {
+      // We don't expect any update task to be running now.
+      assert.equal(this.ionCore._updateInstalledTask, null);
+      // Kick off an update task.
+      let studies =
+        await this.ionCore.runUpdateInstalledStudiesTask(FAKE_STUDY_LIST);
+      assert.equal(studies.length, 2);
+      // Check that the FAKE_STUDY_ID is marked as installed (as per
+      // our fake data, see the beginning of this file).
+      assert.equal(studies
+        .filter(a => (a.addon_id === FAKE_STUDY_ID))
+        .map(a => a.ionInstalled)[0],
+        true);
+      // Check that the FAKE_STUDY_ID_NOT_INSTALLED is marked as
+      // NOT installed.
+      assert.equal(studies
+        .filter(a => (a.addon_id === FAKE_STUDY_ID_NOT_INSTALLED))
+        .map(a => a.ionInstalled)[0],
+        false);
     });
   });
 


### PR DESCRIPTION
This handles the initialization, study installation, study uninstallation cases.

Note that, while this correctly updates the list of available addons with the installation information if addons are installed and uninstalled, it doesn't communicate back to the UI.

Either the UI has to "request" an updated version of the data, or we need to consider a bidirectional communication mechanism to ping the UI, if opened (e.g. [connection-based messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Connection-based_messaging)).

@hamilton thoughts on the UI part?