### PR TITLE
installs study add-ons from core add-on UX, creates functionality for study unenrollment

### DIFF
--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -152,6 +152,16 @@ module.exports = class IonCore {
     await this._sendEnrollmentPing(studyAddonId);
   }
 
+  /**
+   * Unenroll in an Ion Study.
+   *
+   * This sends the required pings.
+   *
+   * @returns {Promise} A promise resolved when the unenrollment
+   *          is complete (does not block on data upload).
+   *          NOTE: this does NOT trigger the study add-on to
+   *          uninstall itself at the moment.
+   */
   async _unenrollStudy(studyAddonId) {
     // We only expect to unenroll in known studies.
     let knownStudies = await this._availableStudies;

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -89,6 +89,11 @@ module.exports = class IonCore {
         // is expecting it.
         return this._enrollStudy(message.data.studyID).then(r => true);
       } break;
+      case "study-unenrollment": {
+        // Let's not forget to respond `true` to the sender: the UI
+        // is expecting it.
+        return this._unenrollStudy(message.data.studyID).then(r => true);
+      } break;
       case "unenrollment": {
         return this._unenroll().then(r => true);
       } break;
@@ -145,6 +150,21 @@ module.exports = class IonCore {
 
     // Finally send the ping.
     await this._sendEnrollmentPing(studyAddonId);
+  }
+
+  async _unenrollStudy(studyAddonId) {
+    // We only expect to unenroll in known studies.
+    let knownStudies = await this._availableStudies;
+    if (!knownStudies.map(s => s.addon_id).includes(studyAddonId)) {
+      return Promise.reject(
+        new Error(`IonCore._unenrollStudy - Unknown study ${studyAddonId}`));
+    }
+    
+    // FIXME: pass message to add-on to remove itself.
+    
+    await this._storage.removeActivatedStudy(studyAddonId);
+    await this._sendDeletionPing(studyId);
+
   }
 
   /**

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -164,7 +164,6 @@ module.exports = class IonCore {
 
     await this._storage.removeActivatedStudy(studyAddonId);
     await this._sendDeletionPing(studyAddonId);
-
   }
 
   /**

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -161,9 +161,9 @@ module.exports = class IonCore {
     }
     
     // FIXME: pass message to add-on to remove itself.
-    
+
     await this._storage.removeActivatedStudy(studyAddonId);
-    await this._sendDeletionPing(studyId);
+    await this._sendDeletionPing(studyAddonId);
 
   }
 

--- a/core-addon/Storage.js
+++ b/core-addon/Storage.js
@@ -59,6 +59,20 @@ module.exports = class Storage {
     return storedIds;
   }
 
+  async removeActivatedStudy(studyId) {
+    let storedIds = await this.getActivatedStudies();
+    if (!storedIds.includes(studyId)) {
+      return storedIds;
+    }
+
+    storedIds = storedIds.filter(s => s !== studyId);
+
+    // Store the updated list.
+    await browser.storage.local.set({activatedStudies: storedIds});
+
+    return storedIds;
+  }
+
   async clearActivatedStudies() {
     return await browser.storage.local.remove("activatedStudies");
   }

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -98,9 +98,18 @@ export default {
       console.debug("Ion Core has nothing to do on study-unenrollment");
       return true;
     }
-    return await sendToCore("study-enrollment", {
+    
+    const enrollResponse = await sendToCore("study-enrollment", {
       studyID
     });
+
+    // Fetch the study add-on and attempt to install it.
+    const studies = await this.getAvailableStudies();
+    const studyMetadata = studies.find(s => s.addon_id === studyID);
+
+    window.location.href = studyMetadata.sourceURI.spec;
+
+    return enrollResponse;
   },
 
   /**

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -107,8 +107,8 @@ export default {
     const studies = await this.getAvailableStudies();
     const studyMetadata = studies.find(s => s.addon_id === studyID);
 
-    // This triggers the install by directing the browser toward the sourceURI,
-    // like a link click.
+    // This triggers the install by directing the page toward the sourceURI,
+    // which is the study add-on's xpi.
     window.location.href = studyMetadata.sourceURI.spec;
 
     return enrollResponse;

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -107,6 +107,8 @@ export default {
     const studies = await this.getAvailableStudies();
     const studyMetadata = studies.find(s => s.addon_id === studyID);
 
+    // This triggers the install by directing the browser toward the sourceURI,
+    // like a link click.
     window.location.href = studyMetadata.sourceURI.spec;
 
     return enrollResponse;

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -96,8 +96,7 @@ export default {
 
   async updateStudyEnrollment(studyID, enroll) {
     if (!enroll) {
-      const unenrollmentResponse = await sendToCore("study-unenrollment", { studyID })
-      return true;
+      return await sendToCore("study-unenrollment", { studyID });
     }
     
     const enrollResponse = await sendToCore("study-enrollment", {

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -21,6 +21,7 @@ async function sendToCore(type, payload) {
     "enrollment",
     "get-studies",
     "study-enrollment",
+    "study-unenrollment",
     "unenrollment",
   ];
 
@@ -95,7 +96,7 @@ export default {
 
   async updateStudyEnrollment(studyID, enroll) {
     if (!enroll) {
-      console.debug("Ion Core has nothing to do on study-unenrollment");
+      const unenrollmentResponse = await sendToCore("study-unenrollment", { studyID })
       return true;
     }
     

--- a/tests/core-addon/Storage.test.js
+++ b/tests/core-addon/Storage.test.js
@@ -87,6 +87,7 @@ describe('Storage', function () {
       assert.ok(!storedIds.includes(TEST_ADDON_ID));
       assert.ok(storedIds.includes('something-else'));
     });
+
     it('should remove the same id only once', async function () {
       const TEST_ADDON_ID = "test-id@ion.com";
       // Return an empty object from the local storage. Note that this

--- a/tests/core-addon/Storage.test.js
+++ b/tests/core-addon/Storage.test.js
@@ -58,6 +58,51 @@ describe('Storage', function () {
     });
   });
 
+  describe('removeActivatedStudy()', async function () {
+    it('should correctly remove on read errors', async function () {
+      const TEST_ADDON_ID = "test-id@ion.com";
+      // Return an empty object from the local storage. Note that this
+      // needs to use `browser` and must use `callsArgWith` to guarantee
+      // that the promise resolves, due to a bug in sinon-chrome. See
+      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
+      browser.storage.local.get.callsArgWith(1, {activatedStudies: [TEST_ADDON_ID]}).throws();
+
+      let storedIds = await this.storage.removeActivatedStudy(TEST_ADDON_ID);
+
+      assert.equal(storedIds.length, 0);
+      assert.ok(!storedIds.includes(TEST_ADDON_ID));
+    });
+    it('should pass through same studies if addon id is not in activated studies', async function () {
+      const TEST_ADDON_ID = "test-id@ion.com";
+      // Return an empty object from the local storage. Note that this
+      // needs to use `browser` and must use `callsArgWith` to guarantee
+      // that the promise resolves, due to a bug in sinon-chrome. See
+      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
+      browser.storage.local.get
+        .callsArgWith(1, {activatedStudies: ['something-else']})
+        .resolves();
+
+      let storedIds = await this.storage.removeActivatedStudy(TEST_ADDON_ID);
+      assert.equal(storedIds.length, 1);
+      assert.ok(!storedIds.includes(TEST_ADDON_ID));
+      assert.ok(storedIds.includes('something-else'));
+    });
+    it('should remove the same id only once', async function () {
+      const TEST_ADDON_ID = "test-id@ion.com";
+      // Return an empty object from the local storage. Note that this
+      // needs to use `browser` and must use `callsArgWith` to guarantee
+      // that the promise resolves, due to a bug in sinon-chrome. See
+      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
+      browser.storage.local.get
+        .callsArgWith(1, {activatedStudies: [TEST_ADDON_ID]})
+        .resolves();
+
+      let storedIds = await this.storage.removeActivatedStudy(TEST_ADDON_ID);
+      assert.equal(storedIds.length, 0);
+      assert.ok(!storedIds.includes(TEST_ADDON_ID));
+    });
+  });
+
   afterEach(function () {
     chrome.flush();
   });

--- a/tests/core-addon/Storage.test.js
+++ b/tests/core-addon/Storage.test.js
@@ -72,6 +72,7 @@ describe('Storage', function () {
       assert.equal(storedIds.length, 0);
       assert.ok(!storedIds.includes(TEST_ADDON_ID));
     });
+
     it('should pass through same studies if addon id is not in activated studies', async function () {
       const TEST_ADDON_ID = "test-id@ion.com";
       // Return an empty object from the local storage. Note that this


### PR DESCRIPTION
closes #41

This PR does the following:

1. finishes the enrollment flow by getting the client to go through the addon install flow (this is done in `web-extension.js` using `window.location.href`, open to other approaches)
2. does a bit of the unenrollment flow (specifically removing the information from `activeStudies` in `Storage.js` via `IonCore.js`) but does not handle the actual study add-on uninstall. For this, we'll have to send a message to the add-on to uninstall itself, since Firefox does not allow the `management` API to uninstall other add-ons.

Would like some feedback on this approach. I'm noticing that this exposes that a bare-minimum to get this MVP working is to have the Core Add-On communicate w/ the demo add-on to tell it to uninstall itself once the user un-enrolls in the demo add-on study.

