### PR TITLE
Add CircleCI to run unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+---
+
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/node:14.13.1
+    steps:
+      - checkout
+      - run: node --version


### PR DESCRIPTION
This adds the CircleCI configuration to fetch a Node image, then run the npm commands to run the tests.