### PR TITLE
Send the uninstall message to all the installed Ion Studies

### DIFF
--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -178,6 +178,46 @@ module.exports = class IonCore {
   }
 
   /**
+   * Sends a message to an available Ion study.
+   *
+   * @param {String} studyId
+   *        The id of the Ion study, as assigned by the platform
+   *        it is deployed on (e.g. a Firefox Addon Id).
+   * @param {String} type
+   *        The type of the message to send. Check `VALID_TYPES`
+   *        for a list of supported types.
+   * @param {Object} payload
+   *        A JSON-serializable object with the message payload.
+   * @returns {Promise} resolved with the response from the study
+   *          if the message was correctly sent, rejected otherwise.
+   */
+  async _sendMessageToStudy(studyId, type, payload) {
+    const VALID_TYPES = [
+      "uninstall",
+    ];
+
+    // Make sure `type` is one of the expected values.
+    if (!VALID_TYPES.includes(type)) {
+      return Promise.reject(
+        new Error(`IonCore._sendMessageToStudy - unexpected message "${type}" to study "${studyId}"`));
+    }
+
+    // Validate the studyId against the list of known studies.
+    let studyList = await this._storage.getActivatedStudies();
+    if (!studyList.includes(studyId)) {
+      return Promise.reject(
+        new Error(`IonCore._sendMessageToStudy - "${studyId}" is not a known Ion study`));
+    }
+
+    const msg = {
+      type,
+      data: payload
+    };
+
+    return await browser.runtime.sendMessage(studyId, msg, {});
+  }
+
+  /**
    * Sends an empty Ion ping with the provided info.
    *
    * @param {String} payloadType

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -157,6 +157,21 @@ module.exports = class IonCore {
    *          is complete (does not block on data upload).
    */
   async _unenroll() {
+    // Uninstall all known studies that are still installed.
+    let installedStudies = (await this._availableStudies)
+      .filter(s => s.ionInstalled)
+      .map(s => s.addon_id);
+    for (let studyId of installedStudies) {
+      // Attempt to send an uninstall message to each study, but
+      // move on if the delivery fails: studies will not be able
+      // to send anything without the Ion Core anyway.
+      try {
+        await this._sendMessageToStudy(studyId, "uninstall", {});
+      } catch (e) {
+        console.error(`IonCore._unenroll - Unable to uninstall ${studyId}`, e);
+      }
+    }
+
     // Read the list of the studies user activated throughout
     // their stay on the Ion platform and send a deletion request
     // for each of them.

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -221,6 +221,7 @@ describe('IonCore', function () {
         .callsArgWith(1, {activatedStudies: [FAKE_STUDY_ID]})
         .resolves();
       browser.storage.local.remove.yields();
+      chrome.runtime.sendMessage.yields();
 
       // Provide a valid study enrollment message.
       await this.ionCore._handleMessage(
@@ -240,6 +241,18 @@ describe('IonCore', function () {
       assert.equal(submitArgs[2].encryptionKeyId, "discarded");
       assert.equal(submitArgs[2].schemaName, "deletion-request");
       assert.equal(submitArgs[2].schemaNamespace, FAKE_STUDY_ID);
+      // We also expect an "uninstall" message to be dispatched to
+      // the one study marked as installed.
+      assert.ok(
+        chrome.runtime.sendMessage.withArgs(
+          FAKE_STUDY_ID,
+          sinon.match({type: "uninstall", data: {}}),
+          // We're not providing any option.
+          {},
+          // This is the callback hidden away by webextension-polyfill.
+          sinon.match.any
+        ).calledOnce
+      );
     });
   });
 

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -291,6 +291,45 @@ describe('IonCore', function () {
     });
   });
 
+  describe('_sendMessageToStudy()', function () {
+    it('rejects on unknown message types', async function () {
+      assert.rejects(
+        this.ionCore._sendMessageToStudy(
+          "unknown-test-study-id@ion.com", "uninstall", {}
+        ),
+        { message: "IonCore._sendMessageToStudy - \"unknown-test-study-id@ion.com\" is not a known Ion study"}
+      );
+    });
+
+    it('rejects on target study ids', async function () {
+      assert.rejects(
+        this.ionCore._sendMessageToStudy(FAKE_STUDY_ID, "unknown-type-test", {}),
+        { message: "IonCore._sendMessageToStudy - unexpected message \"unknown-type-test\" to study \"test@ion-studies.com\""}
+      );
+    });
+
+    it('properly dispatches messages to studies', async function () {
+      let TEST_PAYLOAD = { "someKey": "testValue" };
+
+      // Make sure the function yields during tests!
+      chrome.runtime.sendMessage.yields();
+
+      let response =
+        await this.ionCore._sendMessageToStudy(FAKE_STUDY_ID, "uninstall", TEST_PAYLOAD);
+
+      assert.ok(
+        chrome.runtime.sendMessage.withArgs(
+          FAKE_STUDY_ID,
+          sinon.match({type: "uninstall", data: TEST_PAYLOAD}),
+          // We're not providing any option.
+          {},
+          // This is the callback hidden away by webextension-polyfill.
+          sinon.match.any
+        ).calledOnce
+      );
+    });
+  });
+
   afterEach(function () {
     delete global.fetch;
     chrome.flush();


### PR DESCRIPTION
Fixes #14. The Ion Study part will be handled by mozilla-ion/ion-basic-study#6

Once received, the target Ion Study will uninstall itself.