### PR TITLE
introduces a new local option for the addon build process that allows for locally-available studies list in /public

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,15 @@ web-ext build
 ```
 
 The output will be a `.zip` file in `web-ext-artifacts/` - this should be renamed to `.xpi` for Firefox and `.crx` for Chrome.
+
+## Building and testing a study locally
+
+To run an end-to-end local test with your own study add-on, first build your study (if you don't have one, you can [build the Ion Basic Study](https://github.com/mozilla-ion/ion-basic-study)) and export the build as `<name-of-study>.xpi`. Edit `/public/locally-available-studies.json` so that `sourceURI.spec` is `/public/<name-of-study>.xpi` (you can change the other fields in `/public/locally-available-studies.json` as well for demo purposes as needed). 
+
+Then run:
+
+- `npm run build`
+- `npm run demo-build-addon`
+- `web-ext run --pref=extensions.experiments.enabled=true -f nightly`
+
+To walk through the Core Add-On experience with your study.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The output will be a `.zip` file in `web-ext-artifacts/` - this should be rename
 
 ## Building and testing a study locally
 
-To run an end-to-end local test with your own study add-on, first build your study (if you don't have one, you can [build the Ion Basic Study](https://github.com/mozilla-ion/ion-basic-study)) and export the build as `<name-of-study>.xpi`. Edit `/public/locally-available-studies.json` so that `sourceURI.spec` is `/public/<name-of-study>.xpi` (you can change the other fields in `/public/locally-available-studies.json` as well for demo purposes as needed). 
+To run an end-to-end local test with your own study add-on, first build your study (if you don't have one, you can [build the Ion Basic Study](https://github.com/mozilla-ion/ion-basic-study)) and export the signed build as `<name-of-study>.xpi`. Edit `/public/locally-available-studies.json` so that `sourceURI.spec` is `/public/<name-of-study>.xpi` (you can change the other fields in `/public/locally-available-studies.json` as well for demo purposes as needed). 
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To run an end-to-end local test with your own study add-on, first build your stu
 Then run:
 
 - `npm run build`
-- `npm run demo-build-addon`
+- `npm run local-build-addon`
 - `web-ext run --pref=extensions.experiments.enabled=true -f nightly`
 
 To walk through the Core Add-On experience with your study.

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -7,6 +7,8 @@ const Storage = require("./Storage.js");
 // The path of the embedded resource used to control Ion options.
 const ION_OPTIONS_PAGE_PATH = "public/index.html";
 
+// NOTE: if this URL ever changes, you will have to update the domain in
+// the permissions in manifest.json.
 const ION_DEFAULT_ARGS = {
   availableStudiesURI: "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records"
 }

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -12,6 +12,11 @@ const ION_DEFAULT_ARGS = {
 }
 
 module.exports = class IonCore {
+   /**
+  * @param {Object} args arguments passed in from the user.
+  * @param {String} args.availablStudiesURI the URI where the available Ion studies 
+  *             information is listed.
+  */
   constructor(args = {}) {
     this._userArguments = {...ION_DEFAULT_ARGS, ...args};
 

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -26,7 +26,6 @@ module.exports = class IonCore {
       this._fetchAvailableStudies()
           .then(studies => this.runUpdateInstalledStudiesTask(studies));
   }
- 
   initialize() {
     // Whenever the addon icon is clicked, open the control page.
     browser.browserAction.onClicked.addListener(this._openControlPanel);

--- a/core-addon/background.js
+++ b/core-addon/background.js
@@ -5,5 +5,7 @@
 window.browser = require("webextension-polyfill");
 const IonCore = require("./IonCore.js");
 
-const ionCore = new IonCore();
+const ionCore = new IonCore({
+    availableStudiesURI: __AVAILABLE_ION_STUDIES__
+});
 ionCore.initialize();

--- a/core-addon/background.js
+++ b/core-addon/background.js
@@ -6,6 +6,6 @@ window.browser = require("webextension-polyfill");
 const IonCore = require("./IonCore.js");
 
 const ionCore = new IonCore({
-    availableStudiesURI: __AVAILABLE_ION_STUDIES__
+    availableStudiesURI: __ION_STUDIES_LIST__
 });
 ionCore.initialize();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "rollup -c -w",
     "start": "sirv public",
     "build-addon": "rollup -c rollup.config.addon.js",
-    "local-build-addon": "rollup -c rollup.config.addon.js --config-local-studies",
+    "local-build-addon": "rollup -c rollup.config.addon.js --config-study-list-url=/public/locally-available-studies.json",
     "test-addon": "mocha --require  \"./tests/core-addon/hooks.js\" \"./tests/core-addon/*.js\"",
     "lint-addon": "web-ext lint"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "rollup -c -w",
     "start": "sirv public",
     "build-addon": "rollup -c rollup.config.addon.js",
+    "local-build-addon": "rollup -c rollup.config.addon.js --config-local-studies",
     "test-addon": "mocha --require  \"./tests/core-addon/hooks.js\" \"./tests/core-addon/*.js\"",
     "lint-addon": "web-ext lint"
   },

--- a/public/locally-available-studies.json
+++ b/public/locally-available-studies.json
@@ -1,0 +1,37 @@
+{
+  "data": [
+    {
+      "name": "Ion Base Study",
+      "icons": {
+        "32": "https://addons.cdn.mozilla.net/user-media/addon_icons/2644/2644632-32.png?modified=4a64e2bc",
+        "64": "https://addons.cdn.mozilla.net/user-media/addon_icons/2644/2644632-64.png?modified=4a64e2bc",
+        "128": "https://addons.cdn.mozilla.net/user-media/addon_icons/2644/2644632-128.png?modified=4a64e2bc"
+      },
+      "schema": 1597266497978,
+      "authors": {
+        "url": "https://addons.mozilla.org/en-US/firefox/addon/pioneer-v2-example/",
+        "name": "Pioneer Developers"
+      },
+      "version": "1.0",
+      "addon_id": "pioneer-v2-example@mozilla.org",
+      "moreInfo": {
+        "spec": "https://addons.mozilla.org/en-US/firefox/addon/pioneer-v2-example/"
+      },
+      "isDefault": false,
+      "sourceURI": {
+        "spec": "/public/ion-base-addon.xpi"
+      },
+      "studyType": "extension",
+      "studyEnded": false,
+      "description": "Study purpose: Testing Pioneer.",
+      "privacyPolicy": {
+        "spec": "https://addons.mozilla.org/en-US/firefox/addon/pioneer-v2-example/"
+      },
+      "joinStudyConsent": "This study will send an encrypted ping, only when the toolbar icon is clicked.",
+      "leaveStudyConsent": "This study cannot be re-joined.",
+      "dataCollectionDetails": ["The date and time"],
+      "id": "0eb02750-7159-4f09-96ae-5c7cb7424e89",
+      "last_modified": 1597280277565
+    }
+  ]
+}

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -14,7 +14,7 @@ export default (cliArgs) => {
   },
   plugins: [
     replace({
-      __AVAILABLE_ION_STUDIES__ : cliArgs['config-study-list-url'] ? 
+      __ION_STUDIES_LIST__ : cliArgs['config-study-list-url'] ? 
         `'${cliArgs['config-study-list-url']}'` : 
         "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'"
     }),

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -4,21 +4,22 @@
 
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
+import replace from '@rollup/plugin-replace';
 
-export default {
+export default (cliArgs) => ({
   input: "core-addon/background.js",
   output: {
     file: "public/addon-build/background.js"
   },
   plugins: [
-    // If you have external dependencies installed from
-    // npm, you'll most likely need these plugins. In
-    // some cases you'll need additional configuration -
-    // consult the documentation for details:
-    // https://github.com/rollup/plugins/tree/master/packages/commonjs
+    replace({
+      __AVAILABLE_ION_STUDIES__ : cliArgs['config-local-studies'] ? 
+        "'/public/locally-available-studies.json'" : 
+        "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'"
+    }),
     resolve({
       browser: true,
     }),
     commonjs(),
   ],
-};
+});

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -6,15 +6,16 @@ import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import replace from '@rollup/plugin-replace';
 
-export default (cliArgs) => ({
+export default (cliArgs) => {
+  return {
   input: "core-addon/background.js",
   output: {
     file: "public/addon-build/background.js"
   },
   plugins: [
     replace({
-      __AVAILABLE_ION_STUDIES__ : cliArgs['config-local-studies'] ? 
-        "'/public/locally-available-studies.json'" : 
+      __AVAILABLE_ION_STUDIES__ : cliArgs['config-study-list-url'] ? 
+        `'${cliArgs['config-study-list-url']}'` : 
         "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'"
     }),
     resolve({
@@ -22,4 +23,4 @@ export default (cliArgs) => ({
     }),
     commonjs(),
   ],
-});
+}};


### PR DESCRIPTION
Closes #44 

This _in  theory_ makes it so we can easily build the add-on to point toward a local "available studies" json payload instead of the Remote Settings list. This allows us ways to test study add-ons locally or point to other xpis. It does this by:

- leveraging `@rollup/plugin-replace` to change `core-addon/background.js` to have a swappable URL
- makes `npm run build-addon` use the Remote Settings URI via the above
- makes `npm run local-build-addon` use `/public/locally-available-studies.json` as the target, which can be used by the user to test out any locally-built add-ons.

This isn't probably the most optimal solution in the long run, but I think it should work well for now & allow us to showcase an end-to-end experience w/ the Basic Add-On.