### PR TITLE
Allow Ion studies to send telemetry through the Core Addon

### DIFF
--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -53,7 +53,7 @@ module.exports = class DataCollection {
     // If we were provided with a study id, then this is an enrollment to a study.
     // Send the id alongside with the data and change the schema namespace to simplify
     // the work on the ingestion pipeline.
-    if (typeof studyAddonId != "undefined") {
+    if (studyAddonId !== undefined) {
       return await this._sendEmptyPing("pioneer-enrollment", studyAddonId);
     }
 
@@ -70,7 +70,7 @@ module.exports = class DataCollection {
    *        It's sent in the ping to signal that user unenrolled from a study.
    */
   async sendDeletionPing(studyAddonId) {
-    if (typeof studyAddonId === undefined) {
+    if (studyAddonId === undefined) {
       throw new Error("IonCore - the deletion-request ping requires a study id");
     }
 
@@ -91,11 +91,16 @@ module.exports = class DataCollection {
    * @param {String} keyId
    *        The id of the key used to encrypt the payload.
    * @param {Object} key
-   *        The key used to encrypt the payload, for example:
+   *        The JSON Web Key (JWK) used to encrypt the payload.
+   *        See the RFC 7517 https://tools.ietf.org/html/rfc7517
+   *        for additional information. For example:
+   *
    *        {
-   *          crv: "P-256", kty: "EC",
-   *          x: "XLkI3NaY3-AF2nRMspC63BT1u0Y3moXYSfss7VuQ0mk",
-   *          y: "SB0KnIW-pqk85OIEYZenoNkEyOOp5GeWQhS1KeRtEUE",
+   *          "kty":"EC",
+   *          "crv":"P-256",
+   *          "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+   *          "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+   *          "kid":"Public key used in JWS spec Appendix A.3 example"
    *        }
    */
   async sendPing(payloadType, payload, namespace, keyId, key) {

--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = class DataCollection {
+  /**
+   * Sends an empty Ion ping with the provided info.
+   *
+   * @param {String} payloadType
+   *        The type of the encrypted payload. This will define the
+   *        `schemaName` of the ping.
+   *
+   * @param {String} namespace
+   *        The namespace to route the ping. This will define the
+   *        `schemaNamespace` and `studyName` properties of the ping.
+   */
+  async _sendEmptyPing(payloadType, namespace) {
+    let options = {
+      studyName: namespace,
+      addPioneerId: true,
+      // NOTE - while we're not actually sending useful data in
+      // this payload, the current Ion v2 Telemetry pipeline requires
+      // that pings are shaped this way so they are routed to the correct
+      // environment.
+      //
+      // At the moment, the public key used here isn't important but we do
+      // need to use *something*.
+      encryptionKeyId: "discarded",
+      publicKey: {
+        crv: "P-256",
+        kty: "EC",
+        x: "XLkI3NaY3-AF2nRMspC63BT1u0Y3moXYSfss7VuQ0mk",
+        y: "SB0KnIW-pqk85OIEYZenoNkEyOOp5GeWQhS1KeRtEUE",
+      },
+      schemaName: payloadType,
+      schemaVersion: 1,
+      // Note that the schema namespace directly informs how data is
+      // segregated after ingestion.
+      // If this is an enrollment ping for the pioneer program (in contrast
+      // to the enrollment to a specific study), use a meta namespace.
+      schemaNamespace: namespace,
+    };
+
+    // For enrollment, we expect to send an empty payload.
+    const payload = {};
+
+    // We intentionally don't wait on the promise returned by
+    // `submitExternalPing`, because that's an internal API only meant
+    // for telemetry tests. Moreover, in order to send a custom schema
+    // name and a custom namespace, we need to ship a custom "experimental"
+    // telemetry API for legacy telemetry.
+    await browser.firefoxPrivilegedApi
+      .submitEncryptedPing("pioneer-study", payload, options)
+      .then(() => {
+        console.debug(`IonCore._sendEnrollmentPing - options: ${JSON.stringify(options)} payload: ${JSON.stringify(payload)}`);
+      })
+      .catch(error => {
+        console.error(`IonCore._sendEnrollmentPing failed - error: ${error}`);
+      });
+  }
+
+  /**
+   * Sends a Pioneer enrollment ping.
+   *
+   * The `creationDate` provided by the telemetry APIs will be used as the
+   * timestamp for considering the user enrolled in pioneer and/or the study.
+   *
+   * @param {String} [studyAddonid=undefined]
+   *        optional study id. It's sent in the ping, if present, to signal
+   *        that user enroled in the study.
+   */
+  async sendEnrollmentPing(studyAddonId) {
+    // If we were provided with a study id, then this is an enrollment to a study.
+    // Send the id alongside with the data and change the schema namespace to simplify
+    // the work on the ingestion pipeline.
+    if (typeof studyAddonId != "undefined") {
+      return await this._sendEmptyPing("pioneer-enrollment", studyAddonId);
+    }
+
+    // Note that the schema namespace directly informs how data is segregated after ingestion.
+    // If this is an enrollment ping for the pioneer program (in contrast to the enrollment to
+    // a specific study), use a meta namespace.
+    return await this._sendEmptyPing("pioneer-enrollment", "pioneer-meta");
+  }
+
+  /**
+   * Sends a Ion deletion-request ping.
+   *
+   * @param {String} studyAddonid
+   *        It's sent in the ping to signal that user unenrolled from a study.
+   */
+  async sendDeletionPing(studyAddonId) {
+    if (typeof studyAddonId === undefined) {
+      throw new Error("IonCore - the deletion-request ping requires a study id");
+    }
+
+    return await this._sendEmptyPing("deletion-request", studyAddonId);
+  }
+};

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -150,6 +150,13 @@ module.exports = class IonCore {
     }
 
     switch (message.type) {
+      case "telemetry-ping": {
+        const data = message.data;
+        return await this._dataCollection.sendPing(
+          data.payloadType, data.payload, data.namespace,
+          data.keyId, data.key
+        );
+      } break;
       default:
         return Promise.reject(
           new Error(`IonCore._handleExternalMessage - unexpected message type ${message.type}`));

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Storage = require("./Storage.js");
+const DataCollection = require("./DataCollection.js");
 
 // The path of the embedded resource used to control Ion options.
 const ION_OPTIONS_PAGE_PATH = "public/index.html";
@@ -10,6 +11,7 @@ const ION_OPTIONS_PAGE_PATH = "public/index.html";
 module.exports = class IonCore {
   constructor() {
     this._storage = new Storage();
+    this._dataCollection = new DataCollection();
     // Keep track of the task updating the state of available
     // studies.
     this._updateInstalledTask = null;
@@ -177,7 +179,7 @@ module.exports = class IonCore {
     await browser.firefoxPrivilegedApi.setIonID(uuid);
 
     // Finally send the ping.
-    await this._sendEnrollmentPing();
+    await this._dataCollection.sendEnrollmentPing();
   }
 
   /**
@@ -200,7 +202,7 @@ module.exports = class IonCore {
     await this._storage.appendActivatedStudy(studyAddonId);
 
     // Finally send the ping.
-    await this._sendEnrollmentPing(studyAddonId);
+    await this._dataCollection.sendEnrollmentPing(studyAddonId);
   }
 
   /**
@@ -231,7 +233,7 @@ module.exports = class IonCore {
     }
 
     await this._storage.removeActivatedStudy(studyAddonId);
-    await this._sendDeletionPing(studyAddonId);
+    await this._dataCollection.sendDeletionPing(studyAddonId);
   }
 
   /**
@@ -264,7 +266,7 @@ module.exports = class IonCore {
     // for each of them.
     let studyList = await this._storage.getActivatedStudies();
     for (let studyId of studyList) {
-      await this._sendDeletionPing(studyId);
+      await this._dataCollection.sendDeletionPing(studyId);
     }
 
     // Clear locally stored Ion ID.
@@ -317,100 +319,6 @@ module.exports = class IonCore {
     };
 
     return await browser.runtime.sendMessage(studyId, msg, {});
-  }
-
-  /**
-   * Sends an empty Ion ping with the provided info.
-   *
-   * @param {String} payloadType
-   *        The type of the encrypted payload. This will define the
-   *        `schemaName` of the ping.
-   *
-   * @param {String} namespace
-   *        The namespace to route the ping. This will define the
-   *        `schemaNamespace` and `studyName` properties of the ping.
-   */
-  async _sendEmptyPing(payloadType, namespace) {
-    let options = {
-      studyName: namespace,
-      addPioneerId: true,
-      // NOTE - while we're not actually sending useful data in
-      // this payload, the current Ion v2 Telemetry pipeline requires
-      // that pings are shaped this way so they are routed to the correct
-      // environment.
-      //
-      // At the moment, the public key used here isn't important but we do
-      // need to use *something*.
-      encryptionKeyId: "discarded",
-      publicKey: {
-        crv: "P-256",
-        kty: "EC",
-        x: "XLkI3NaY3-AF2nRMspC63BT1u0Y3moXYSfss7VuQ0mk",
-        y: "SB0KnIW-pqk85OIEYZenoNkEyOOp5GeWQhS1KeRtEUE",
-      },
-      schemaName: payloadType,
-      schemaVersion: 1,
-      // Note that the schema namespace directly informs how data is
-      // segregated after ingestion.
-      // If this is an enrollment ping for the pioneer program (in contrast
-      // to the enrollment to a specific study), use a meta namespace.
-      schemaNamespace: namespace,
-    };
-
-    // For enrollment, we expect to send an empty payload.
-    const payload = {};
-
-    // We intentionally don't wait on the promise returned by
-    // `submitExternalPing`, because that's an internal API only meant
-    // for telemetry tests. Moreover, in order to send a custom schema
-    // name and a custom namespace, we need to ship a custom "experimental"
-    // telemetry API for legacy telemetry.
-    await browser.firefoxPrivilegedApi
-      .submitEncryptedPing("pioneer-study", payload, options)
-      .then(() => {
-        console.debug(`IonCore._sendEnrollmentPing - options: ${JSON.stringify(options)} payload: ${JSON.stringify(payload)}`);
-      })
-      .catch(error => {
-        console.error(`IonCore._sendEnrollmentPing failed - error: ${error}`);
-      });
-  }
-
-  /**
-   * Sends a Pioneer enrollment ping.
-   *
-   * The `creationDate` provided by the telemetry APIs will be used as the
-   * timestamp for considering the user enrolled in pioneer and/or the study.
-   *
-   * @param {String} [studyAddonid=undefined]
-   *        optional study id. It's sent in the ping, if present, to signal
-   *        that user enroled in the study.
-   */
-  async _sendEnrollmentPing(studyAddonId) {
-    // If we were provided with a study id, then this is an enrollment to a study.
-    // Send the id alongside with the data and change the schema namespace to simplify
-    // the work on the ingestion pipeline.
-    if (typeof studyAddonId != "undefined") {
-      return await this._sendEmptyPing("pioneer-enrollment", studyAddonId);
-    }
-
-    // Note that the schema namespace directly informs how data is segregated after ingestion.
-    // If this is an enrollment ping for the pioneer program (in contrast to the enrollment to
-    // a specific study), use a meta namespace.
-    return await this._sendEmptyPing("pioneer-enrollment", "pioneer-meta");
-  }
-
-  /**
-   * Sends a Ion deletion-request ping.
-   *
-   * @param {String} studyAddonid
-   *        It's sent in the ping to signal that user unenrolled from a study.
-   */
-  async _sendDeletionPing(studyAddonId) {
-    if (typeof studyAddonId === undefined) {
-      throw new Error("IonCore - the deletion-request ping requires a study id");
-    }
-
-    return await this._sendEmptyPing("deletion-request", studyAddonId);
   }
 
   /**

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -135,7 +135,7 @@ module.exports = class IonCore {
    * @param {Object} message
    *        The payload of the message.
    * @param {runtime.MessageSender} sender
-   *        An object containing informations about who sent
+   *        An object containing information about who sent
    *        the message.
    * @returns {Promise} The response to the received message.
    *          It can be resolved with a value that is sent to the
@@ -151,10 +151,9 @@ module.exports = class IonCore {
 
     switch (message.type) {
       case "telemetry-ping": {
-        const data = message.data;
+        const {payloadType, payload, namespace, keyId, key} = message.data;
         return await this._dataCollection.sendPing(
-          data.payloadType, data.payload, data.namespace,
-          data.keyId, data.key
+          payloadType, payload, namespace, keyId, key
         );
       } break;
       default:

--- a/tests/core-addon/DataCollection.test.js
+++ b/tests/core-addon/DataCollection.test.js
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var assert = require('assert');
+var sinon = require('sinon');
+
+var DataCollection = require('../../core-addon/DataCollection');
+
+describe('DataCollection', function () {
+  // A fake study id to use in the tests when looking for a
+  // "known" study.
+  FAKE_STUDY_ID = "test@ion-studies.com";
+
+  beforeEach(function () {
+    this.dataCollection = new DataCollection();
+  });
+
+  describe('sendEnrollmentPing()', function () {
+    it('generates the correct ping for the platform', async function () {
+      // Create a mock for the privileged API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.firefoxPrivilegedApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
+
+      // Provide a valid enrollment message.
+      await this.dataCollection.sendEnrollmentPing();
+
+      // We expect to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... an empty payload ...
+      assert.equal(Object.keys(submitArgs[1]).length, 0);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, "pioneer-meta");
+      assert.equal(submitArgs[2].encryptionKeyId, "discarded");
+      assert.equal(submitArgs[2].schemaName, "pioneer-enrollment");
+      assert.equal(submitArgs[2].schemaNamespace, "pioneer-meta");
+    });
+
+    it('generates the correct ping for the study', async function () {
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.firefoxPrivilegedApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
+
+      // Provide a valid study enrollment message.
+      await this.dataCollection.sendEnrollmentPing(FAKE_STUDY_ID);
+
+      // We expect to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... an empty payload ...
+      assert.equal(Object.keys(submitArgs[1]).length, 0);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, FAKE_STUDY_ID);
+      assert.equal(submitArgs[2].encryptionKeyId, "discarded");
+      assert.equal(submitArgs[2].schemaName, "pioneer-enrollment");
+      assert.equal(submitArgs[2].schemaNamespace, FAKE_STUDY_ID);
+    });
+  });
+
+  describe('sendDeletionPing()', function () {
+    it('rejects if no study id is provided', function () {
+      assert.rejects(
+        this.dataCollection.sendDeletionPing(),
+        { message: "IonCore - the deletion-request ping requires a study id"}
+      );
+    });
+
+    it('generates the deletion ping for the study', async function () {
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.firefoxPrivilegedApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        clearIonID: async function() {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
+
+      // Provide a valid study enrollment message.
+      await this.dataCollection.sendDeletionPing(FAKE_STUDY_ID);
+
+      // We expect to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... an empty payload ...
+      assert.equal(Object.keys(submitArgs[1]).length, 0);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, FAKE_STUDY_ID);
+      assert.equal(submitArgs[2].encryptionKeyId, "discarded");
+      assert.equal(submitArgs[2].schemaName, "deletion-request");
+      assert.equal(submitArgs[2].schemaNamespace, FAKE_STUDY_ID);
+    });
+  });
+
+  afterEach(function () {
+    chrome.flush();
+  });
+});

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -316,6 +316,30 @@ describe('IonCore', function () {
     });
   });
 
+  describe('_handleExternalMessage()', function () {
+    it('rejects unknown messages', function () {
+      // Provide an unknown message type and a valid sender:
+      // it should fail due to the unexpected type.
+      assert.rejects(
+        this.ionCore._handleExternalMessage(
+          {type: "test-unknown-type", data: {}},
+          {id: FAKE_STUDY_ID}
+        ),
+        { message: "IonCore._handleExternalMessage - unexpected message type test-unknown-type"}
+      );
+    });
+
+    it('rejects unknown senders', function () {
+      assert.rejects(
+        this.ionCore._handleExternalMessage(
+          {type: "irrelevant-as-fails-earlier", data: {}},
+          {id: "unknown-test-study-id"}
+        ),
+        { message: "IonCore._handleExternalMessage - unexpected sender unknown-test-study-id"}
+      );
+    });
+  });
+
   describe('_enrollStudy()', function () {
     it('rejects unknown study ids', function () {
       assert.rejects(


### PR DESCRIPTION
Fixes #47 .

This PR adds the ability to receive messages from known Ion Studies and does a bit of refactoring to move data collection code to its own module.

It also adds a message to send telemetry from an Ion study.

**DO NOT MERGE**: It's missing test coverage for the "telemetry-ping" message. I'll add that tomorrow morning.