### PR TITLE
point default local remotesettings file at ion basic add-on on AMO

### DIFF
--- a/public/locally-available-studies.json
+++ b/public/locally-available-studies.json
@@ -12,14 +12,14 @@
         "url": "https://addons.mozilla.org/en-US/firefox/addon/ion-basic-study/",
         "name": "Ion Developers"
       },
-      "version": "2.0",
+      "version": "2.1",
       "addon_id": "ion-basic-study@mozilla.org",
       "moreInfo": {
         "spec": "https://addons.mozilla.org/en-US/firefox/addon/ion-basic-study/"
       },
       "isDefault": false,
       "sourceURI": {
-        "spec": "https://addons.mozilla.org/firefox/downloads/file/3659906/ion_basic_study-2.0-fx.xpi"
+        "spec": "https://addons.mozilla.org/firefox/downloads/file/3661128/ion_basic_study-2.1-fx.xpi"
       },
       "studyType": "extension",
       "studyEnded": false,

--- a/public/locally-available-studies.json
+++ b/public/locally-available-studies.json
@@ -3,29 +3,29 @@
     {
       "name": "Ion Base Study",
       "icons": {
-        "32": "https://addons.cdn.mozilla.net/user-media/addon_icons/2644/2644632-32.png?modified=4a64e2bc",
-        "64": "https://addons.cdn.mozilla.net/user-media/addon_icons/2644/2644632-64.png?modified=4a64e2bc",
-        "128": "https://addons.cdn.mozilla.net/user-media/addon_icons/2644/2644632-128.png?modified=4a64e2bc"
+        "32": "https://addons.cdn.mozilla.net/static/img/addon-icons/default-32.png",
+        "64": "https://addons.cdn.mozilla.net/static/img/addon-icons/default-64.png",
+        "128": "https://addons.cdn.mozilla.net/static/img/addon-icons/default-128.png"
       },
       "schema": 1597266497978,
       "authors": {
-        "url": "https://addons.mozilla.org/en-US/firefox/addon/pioneer-v2-example/",
-        "name": "Pioneer Developers"
+        "url": "https://addons.mozilla.org/en-US/firefox/addon/ion-basic-study/",
+        "name": "Ion Developers"
       },
-      "version": "1.0",
-      "addon_id": "pioneer-v2-example@mozilla.org",
+      "version": "2.0",
+      "addon_id": "ion-basic-study@mozilla.org",
       "moreInfo": {
-        "spec": "https://addons.mozilla.org/en-US/firefox/addon/pioneer-v2-example/"
+        "spec": "https://addons.mozilla.org/en-US/firefox/addon/ion-basic-study/"
       },
       "isDefault": false,
       "sourceURI": {
-        "spec": "/public/ion-base-addon.xpi"
+        "spec": "https://addons.mozilla.org/firefox/downloads/file/3659906/ion_basic_study-2.0-fx.xpi"
       },
       "studyType": "extension",
       "studyEnded": false,
-      "description": "Study purpose: Testing Pioneer.",
+      "description": "Study purpose: Testing Ion.",
       "privacyPolicy": {
-        "spec": "https://addons.mozilla.org/en-US/firefox/addon/pioneer-v2-example/"
+        "spec": "https://addons.mozilla.org/en-US/firefox/addon/ion-basic-study/"
       },
       "joinStudyConsent": "This study will send an encrypted ping, only when the toolbar icon is clicked.",
       "leaveStudyConsent": "This study cannot be re-joined.",


### PR DESCRIPTION
@hamilton note that this also changes the XPI URL to point to AMO, if you want to keep it inside the `ion-core-addon` repo that's OK too.