### PR TITLE
 signature verification must be turned off for AMO

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -187,7 +187,10 @@
       <b style="text-transform: uppercase">Note</b> – this is demoware. You're
       going to need to run Nightly and set in <code>about:config</code> the
       following:
-      <ul>
+      <ul>        
+        <li>
+          <code>xpinstall.signatures.required = false</code>
+        </li>
         <li>
           <code>xpinstall.signatures.dev-root = true</code> (this does not
           exist and must be created)


### PR DESCRIPTION
Since we're switching to the `dev-root`, AMO add-ons no longer appear to be valid. This overrides that. We still need `dev-root` in order to get the privileged code to load for the core add-on. Once we're using production keys this all goes away :)