### PR TITLE
Ensure `this` exists when receiving external messages

### DIFF
--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -79,7 +79,8 @@ module.exports = class IonCore {
     //
     // We want the handler to be async to conveniently handle all the
     // asynchronous calls and updates to the studies list.
-    browser.runtime.onMessageExternal.addListener(this._handleExternalMessage);
+    browser.runtime.onMessageExternal.addListener(
+      async (m, s) => this._handleExternalMessage(m, s));
   }
 
   _openControlPanel() {


### PR DESCRIPTION
This fixes the `_handleExternalMessage` handler registration, which was mistakenly not binding the `this` context. This unblocks sending telemetry from the basic study.