### PR TITLE
Send enrollment/deletion when addons lifetime changes

### DIFF
--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -31,6 +31,8 @@ module.exports = class IonCore {
 
     // Asynchronously get the available studies. We don't need to wait
     // for this to finish, the UI can handle the wait.
+    // TODO: we don't really need "runUpdateINstall..." anymore, because
+    // we're synching up with the addon install/uninstall events.
     this._availableStudies =
       this._fetchAvailableStudies()
           .then(studies => this.runUpdateInstalledStudiesTask(studies));
@@ -56,14 +58,13 @@ module.exports = class IonCore {
 
     // Listen for addon install/uninstall and keep the studies
     // installation state up to date.
-    let addonStateHandler = async () => {
-      let studies = await this._availableStudies;
-      // Update the studies list.
-      this._availableStudies = this._availableStudies.then(
-        studies => this.runUpdateInstalledStudiesTask(studies));
-    };
-    browser.management.onInstalled.addListener(addonStateHandler);
-    browser.management.onUninstalled.addListener(addonStateHandler);
+    browser.management.onInstalled.addListener(
+      info => this._handleAddonLifecycle(info, true));
+    // The only reason why we need to listen for uninstallation events
+    // is to catch studies being uninstalled outside of the control
+    // panel.
+    browser.management.onUninstalled.addListener(
+      info => this._handleAddonLifecycle(info, false));
 
     // Listen for incoming messages from the studies.
     //
@@ -90,6 +91,47 @@ module.exports = class IonCore {
     browser.runtime.openOptionsPage().catch(e => {
       console.error(`IonCore.js - Unable to open the control panel`, e);
     });
+  }
+
+  /**
+   * React to studies installation and uninstallation.
+   *
+   * @param {ExtensionInfo} info
+   *        The information about the addon that triggered the event.
+   * @param {Boolean} installed
+   *        `true` if the addon was installed, `false` otherwise.
+   * @returns {Promise} resolved when the new state is completely
+   *          handled.
+   */
+  async _handleAddonLifecycle(info, installed) {
+    // Don't do anything if we received an updated from an addon
+    // that's not an Ion study.
+    let knownStudies = await this._availableStudies;
+    if (!knownStudies.map(s => s.addon_id).includes(info.id)) {
+      console.debug(
+        `IonCore._handleAddonLifecycle - non-study addon ${info.id} was ${installed ? "installed" : "uninstalled"}`
+      );
+      return;
+    }
+
+    // Update the available studies list with the installation
+    // information.
+    this._availableStudies = Promise.resolve(knownStudies.map(s => {
+        if (s.addon_id == info.id) {
+          s.ionInstalled = installed;
+        }
+        return s;
+      })
+    );
+
+    if (installed) {
+      await this._enrollStudy(info.id);
+    } else {
+      // Handle the case of addons being uninstalled manually.
+      await this._unenrollStudy(info.id);
+    }
+
+    await this._sendStateUpdateToUI();
   }
 
   /**
@@ -135,23 +177,21 @@ module.exports = class IonCore {
 
     switch (message.type) {
       case "enrollment": {
-        return this._enroll();
+        return this._enroll()
+                   .then(r => this._sendStateUpdateToUI());
       } break;
       case "get-studies": {
-        this._availableStudies.then(studies => {
-          this._connectionPort.postMessage(
-            {type: "get-studies-response", data: studies});
-        });
-        return Promise.resolve();
-      } break;
-      case "study-enrollment": {
-        return this._enrollStudy(message.data.studyID);
+        return this._sendStateUpdateToUI();
       } break;
       case "study-unenrollment": {
+        // We still need to handle this message, even if we're catching
+        // addon "uninstall" events: we want users to be able to uninstall
+        // from the control panel.
         return this._unenrollStudy(message.data.studyID);
       } break;
       case "unenrollment": {
-        return this._unenroll();
+        return this._unenroll()
+                   .then(r => this._sendStateUpdateToUI());
       } break;
       default:
         return Promise.reject(
@@ -266,7 +306,8 @@ module.exports = class IonCore {
 
     // Attempt to send an uninstall message, but move on if the
     // delivery fails: studies will not be able to send anything
-    // without the Ion Core anyway.
+    // without the Ion Core anyway. Moreover, they might have been
+    // removed manually from the addons pages (e.g. about:addons).
     try {
       await this._sendMessageToStudy(studyAddonId, "uninstall", {});
     } catch (e) {
@@ -432,5 +473,58 @@ module.exports = class IonCore {
       console.error(err);
       return [];
     }
+  }
+
+  /**
+   * Send a message with the latest state to the UI.
+   *
+   * The state has the following format:
+   *
+   * ```js
+   * {
+   *  // The enrollment as a Boolean indicating if user joined
+   *  // the platform.
+   *  enrolled: true,
+   *  // An array with a list of studies, fetched from our servers,
+   *  // and integrated with the install status.
+   *  availableStudies: [
+   *    {
+   *      name: "Demo Study",
+   *      icons: { ... },
+   *      schema: ...,
+   *      authors { ... },
+   *      version: "1.0",
+   *      addon_id: "demo-study@ion.org",
+   *      moreInfo: { ... },
+   *      isDefault: false,
+   *      sourceURI: { ... },
+   *      studyType: "extension",
+   *      studyEnded: false,
+   *      description: "Some nice description",
+   *      privacyPolicy: { ... },
+   *      joinStudyConsent: "...",
+   *      leaveStudyConsent: "...",
+   *      dataCollectionDetails: [ ... ],
+   *      id:"...",
+   *      last_modified: ...,
+   *      // Whether or not the study is currently installed.
+   *      ionInstalled: false
+   *    },
+   *  ]
+   * }
+   * ```
+   */
+  async _sendStateUpdateToUI() {
+    let enrolled = !!(await this._storage.getIonID());
+    let availableStudies = await this._availableStudies;
+
+    const newState = {
+      enrolled,
+      availableStudies,
+    };
+
+    // Send a message to the UI to update the list of studies.
+    this._connectionPort.postMessage(
+      {type: "update-state", data: newState});
   }
 }

--- a/core-addon/Storage.js
+++ b/core-addon/Storage.js
@@ -3,8 +3,42 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = class Storage {
+  /**
+   * Gets the stored value from the local browser storage.
+   *
+   * @param {String} key
+   *        The name of the key to retrieve data from.
+   */
+  async getItem(key) {
+    try {
+      return (await browser.storage.local.get(key))[key];
+    } catch (err) {
+      console.error(`Storage - failed to read ${key} from the local storage`, error);
+      return Promise.resolve();
+    }
+  }
+
+  /**
+   * Store a value in the local browser storage.
+   *
+   * @param {String} key
+   *        The name of the key to store data into.
+   * @param {<Primitive Type> or Array} value
+   *        The value to store. It can be any of the primitive
+   *        types (e.g. numbers, booleans) or Array types. See
+   *        the documentation for additional information:
+   *        https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
+   */
+  async setItem(key, value) {
+    return browser.storage.local.set({ [key]: value });
+  }
+
+  async getIonID() {
+    return await this.getItem("ionId");
+  }
+
   async setIonID(uuid) {
-    return await browser.storage.local.set({ionId: uuid});
+    return await this.setItem("ionId", uuid);
   }
 
   async clearIonID() {
@@ -19,16 +53,12 @@ module.exports = class Storage {
    */
   async getActivatedStudies() {
     // Attempt to retrieve any previously stored study ids.
-    return await browser.storage.local.get("activatedStudies").then(
+    return await this.getItem("activatedStudies").then(
         stored => {
           // This branch will be hit even if `activatedStudies` was never
           // stored (e.g. this is the first save). Make sure to account for
           // that case by returning an empty array.
-          return stored.activatedStudies || [];
-        },
-        error => {
-          console.error("Storage - failed to read from the local storage", error);
-          return [];
+          return stored || [];
         }
       );
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@storybook/addon-links": "^6.0.26",
     "@storybook/svelte": "^6.0.26",
     "babel-loader": "^8.1.0",
-    "immer": "^7.0.9",
     "mocha": "^8.1.3",
     "react-is": "^16.13.1",
     "rollup": "^2.3.4",

--- a/src/create-store.js
+++ b/src/create-store.js
@@ -1,33 +1,24 @@
 import { writable } from "svelte/store";
 import { produce } from "immer/dist/immer.cjs.production.min.js";
 
-const STORE_KEY = "__STATE__";
 export default function createStore(initialState, api) {
   // initialize the writable store.
   const { subscribe, update, set } = writable();
 
   // initialize from the API.
-  api.initialize(STORE_KEY, initialState).then(async (remoteInitialState) => {
+  api.initialize(initialState).then(async (remoteInitialState) => {
+    console.log('initialize', remoteInitialState, initialState);
     const state = remoteInitialState || initialState;
     state.availableStudies = await api.getAvailableStudies();
     set(state);
   });
 
+  // set UI when the background script reports a new state.
+  api.onNextState(set);
+
   return {
     subscribe,
     set,
-    produce(fcn) {
-      update((draft) => {
-        const nextState = produce(draft, fcn);
-        api.setItem(STORE_KEY, nextState);
-        return nextState;
-      });
-    },
-    setField(key, value) {
-      this.produce((state) => {
-        state[key] = value;
-      });
-    },
     async updateStudyEnrollment(studyID, enroll) {
       // Enforce the truthyness of `enroll`, to make sure
       // it's always a boolean.
@@ -35,24 +26,11 @@ export default function createStore(initialState, api) {
       console.debug(
         `Ion - changing study ${studyID} enrollment to ${coercedEnroll}`);
 
-      let outcome;
       // send study enrollment message
       try {
-        outcome = await api.updateStudyEnrollment(studyID, coercedEnroll);
+        await api.updateStudyEnrollment(studyID, coercedEnroll);
       } catch (err) {
         console.error(err);
-      }
-      // if study enrollment is successful, update frontend.
-      if (outcome) {
-        this.produce((draft) => {
-          if (draft.activeStudies.includes(studyID)) {
-            draft.activeStudies = draft.activeStudies.filter(
-              (id) => id !== studyID
-            );
-          } else {
-            draft.activeStudies.push(studyID);
-          }
-        });
       }
     },
     async updateIonEnrollment(enroll) {
@@ -61,18 +39,11 @@ export default function createStore(initialState, api) {
       let coercedEnroll = !!enroll;
       console.debug(`Ion - changing enrollment to ${coercedEnroll}`);
 
-      let outcome;
       // send the ion enrollment message
       try {
-        outcome = await api.updateIonEnrollment(coercedEnroll);
+        await api.updateIonEnrollment(coercedEnroll);
       } catch (err) {
         console.error(err);
-      }
-      // if ion enrollment is successful, update frontend.
-      if (outcome) {
-        this.produce((draft) => {
-          draft.enrolled = coercedEnroll;
-        });
       }
     },
   };

--- a/src/create-store.js
+++ b/src/create-store.js
@@ -1,5 +1,4 @@
 import { writable } from "svelte/store";
-import { produce } from "immer/dist/immer.cjs.production.min.js";
 
 export default function createStore(initialState, api) {
   // initialize the writable store.

--- a/src/mocks/firefox-mock.js
+++ b/src/mocks/firefox-mock.js
@@ -1,5 +1,4 @@
 export default {
   enrolled: false,
-  activeStudies: [],
   availableStudies: [],
 };

--- a/src/regions/StudyList.svelte
+++ b/src/regions/StudyList.svelte
@@ -20,8 +20,8 @@
       studyId={study.addon_id}
       enrolled={$store.enrolled}
       privacyPolicy={study.privacyPolicy.spec}
-      studyEnrolled={$store.activeStudies.includes(study.addon_id)}
-      on:enroll={() => store.updateStudyEnrollment(study.addon_id, !$store.activeStudies.includes(study.addon_id))}>
+      studyEnrolled={study.ionInstalled}
+      on:enroll={() => store.updateStudyEnrollment(study.addon_id, !study.ionInstalled)}>
       <span slot="name">{study.name}</span>
       <span slot="authors">{study.authors.name}</span>
       <span slot="description">{study.description}</span>

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -411,13 +411,13 @@ describe('IonCore', function () {
     });
   });
 
-  describe('runUpdateInstalledStudiesTask()', function () {
+  describe('_updateInstalledStudies()', function () {
     it('adds the ionInstalled property', async function () {
       // We don't expect any update task to be running now.
       assert.equal(this.ionCore._updateInstalledTask, null);
       // Kick off an update task.
       let studies =
-        await this.ionCore.runUpdateInstalledStudiesTask(FAKE_STUDY_LIST);
+        await this.ionCore._updateInstalledStudies(FAKE_STUDY_LIST);
       assert.equal(studies.length, 2);
       // Check that the FAKE_STUDY_ID is marked as installed (as per
       // our fake data, see the beginning of this file).

--- a/tests/core-addon/Storage.test.js
+++ b/tests/core-addon/Storage.test.js
@@ -12,6 +12,16 @@ describe('Storage', function () {
     this.storage = new Storage();
   });
 
+  describe('getItem()', async function () {
+    it('should return undefined on errors', async function () {
+      chrome.storage.local.get.rejects();
+
+      let stored = await this.storage.getItem("irrelevant-key");
+
+      assert.ok(stored === undefined);
+    });
+  });
+
   describe('appendActivatedStudy()', async function () {
     it('should correctly append studies on first run', async function () {
       const TEST_ADDON_ID = "test-id@ion.com";


### PR DESCRIPTION
Fixes #81, #60.

This adds an `update-state` message sent by the background script to the UI. With this PR, the state is no longer duplicated between the UI storage and the background storage: the latter is the only source of truth.

This incorporate the work from @hamilton that updates the PR.