### PR TITLE
Enable the platform website to check for Core Addon installation

### DIFF
--- a/core-addon/background.js
+++ b/core-addon/background.js
@@ -6,6 +6,7 @@ window.browser = require("webextension-polyfill");
 const IonCore = require("./IonCore.js");
 
 const ionCore = new IonCore({
-    availableStudiesURI: __ION_STUDIES_LIST__
+    availableStudiesURI: __ION_STUDIES_LIST__,
+    website: __ION_WEBSITE_URL__,
 });
 ionCore.initialize();

--- a/core-addon/content-script.js
+++ b/core-addon/content-script.js
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+window.browser = require("webextension-polyfill");
+
+/**
+ * Send an event to the web page.
+ *
+ * @param {Object} message
+ *        A JSON-serializable object to send back to the
+ *        page. It must have the following structure:
+ *        {type: "message-type", data: {...}}
+ */
+function sendToPage(message) {
+  console.debug(`Ion: sending response ${message.type} to page`);
+  const data = message.data || {};
+  window.dispatchEvent(new CustomEvent(message.type, { detail: data }));
+}
+
+function sendAddonAliveEvent() {
+  sendToPage({type: "web-check-response", data: {}})
+}
+
+/**
+ * Bridge page events to the background script.
+ *
+ * ** IMPORTANT **
+ *
+ * All the messages passing through here must NOT BE TRUSTED, as
+ * any actor could inject custom scripts and impersonate the web page.
+ */
+window.addEventListener("web-check", event => {
+  console.debug("Ion - 'web-check' message received from the page");
+  // TODO: can we automatically get the addon id for the right platform
+  // at build time?
+  browser
+    .runtime
+    .sendMessage(
+        "ion-core-addon@mozilla.org",
+        {type: "web-check", data: {}},
+        {}
+      )
+      .then(
+        resolved => sendAddonAliveEvent(),
+        // Even if the message was rejected, this script from the addon
+        // was still injected, so the addon must be there!
+        rejected => sendAddonAliveEvent()
+      );
+});
+
+console.debug("Ion - Running content script");
+// Send an event as soon as injected, to notify the web page if
+// it is already open.
+sendAddonAliveEvent();

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,6 +154,25 @@
         font-weight: 600;
       }
     </style>
+    <script type="text/javascript">
+      // Always install this handler:
+      //
+      // - if the addon is already installed, it will respond to the message
+      //   we'll send on page load;
+      // - if the addon is not installed, it will send a message as soon as
+      //   it gets installed.
+      window.addEventListener("web-check-response", event => {
+        console.debug("Ion - 'web-check-response' message received from the Core Addon");
+        document.getElementById("installButton").style.display = "none";
+        document.getElementById("installedBlob").style.display = "block";
+      });
+
+      // Dispatch a 'web-check' event as soon as the page is loaded:
+      // if the addon is already installed, we will receive a response.
+      window.onload = () => {
+        window.dispatchEvent(new CustomEvent("web-check", { detail: {} }));
+      }
+    </script>
   </head>
   <body>
     <h1>
@@ -179,15 +198,19 @@
       Put your data to work for a better internet.
     </h1>
     <a
+      id="installButton"
       tabindex="0"
       href="https://github.com/mozilla-ion/ion-core-addon/releases/download/2.1/ion_core-2.1.xpi"
       >Install the Ion Web Extension</a
     >
+    <div id="installedBlob" style="display: none">
+      Congratulations! Ion is installed and ready!
+    </div>
     <div>
       <b style="text-transform: uppercase">Note</b> – this is demoware. You're
       going to need to run Nightly and set in <code>about:config</code> the
       following:
-      <ul>        
+      <ul>
         <li>
           <code>xpinstall.signatures.required = false</code>
         </li>

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,17 @@
     ]
   },
 
+  "content_scripts": [
+    {
+      "matches": [
+        "https://mozilla-ion.github.io/*"
+      ],
+      "js": [
+        "public/addon-build/content-script.js"
+      ]
+    }
+  ],
+
   "browser_action": {
     "default_icon": "images/ion.svg"
   },

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -14,9 +14,12 @@ export default (cliArgs) => {
   },
   plugins: [
     replace({
-      __ION_STUDIES_LIST__ : cliArgs['config-study-list-url'] ? 
-        `'${cliArgs['config-study-list-url']}'` : 
-        "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'"
+      __ION_STUDIES_LIST__: cliArgs['config-study-list-url'] ?
+        `'${cliArgs['config-study-list-url']}'` :
+        "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'",
+      __ION_WEBSITE_URL__: cliArgs['config-website'] ?
+        `'${cliArgs['config-website']}'` :
+        "'https://mozilla-ion.github.io'",
     }),
     resolve({
       browser: true,

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -7,23 +7,37 @@ import resolve from "@rollup/plugin-node-resolve";
 import replace from '@rollup/plugin-replace';
 
 export default (cliArgs) => {
-  return {
-  input: "core-addon/background.js",
-  output: {
-    file: "public/addon-build/background.js"
+  return [
+  {
+    input: "core-addon/background.js",
+    output: {
+      file: "public/addon-build/background.js"
+    },
+    plugins: [
+      replace({
+        __ION_STUDIES_LIST__: cliArgs['config-study-list-url'] ?
+          `'${cliArgs['config-study-list-url']}'` :
+          "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'",
+        __ION_WEBSITE_URL__: cliArgs['config-website'] ?
+          `'${cliArgs['config-website']}'` :
+          "'https://mozilla-ion.github.io'",
+      }),
+      resolve({
+        browser: true,
+      }),
+      commonjs(),
+    ],
   },
-  plugins: [
-    replace({
-      __ION_STUDIES_LIST__: cliArgs['config-study-list-url'] ?
-        `'${cliArgs['config-study-list-url']}'` :
-        "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'",
-      __ION_WEBSITE_URL__: cliArgs['config-website'] ?
-        `'${cliArgs['config-website']}'` :
-        "'https://mozilla-ion.github.io'",
-    }),
-    resolve({
-      browser: true,
-    }),
-    commonjs(),
-  ],
-}};
+  {
+    input: "core-addon/content-script.js",
+    output: {
+      file: "public/addon-build/content-script.js"
+    },
+    plugins: [
+      resolve({
+        browser: true,
+      }),
+      commonjs(),
+    ],
+  },
+]};

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -20,6 +20,7 @@ describe('IonCore', function () {
       "addon_id": FAKE_STUDY_ID_NOT_INSTALLED
     }
   ];
+  FAKE_WEBSITE = "https://test.website";
 
   beforeEach(function () {
     // Force the sinon-chrome stubbed API to resolve its promise
@@ -44,7 +45,9 @@ describe('IonCore', function () {
       }
     });
 
-    this.ionCore = new IonCore();
+    this.ionCore = new IonCore({
+      website: FAKE_WEBSITE
+    });
 
     // Mock the channel to the UI.
     this.ionCore._connectionPort = {
@@ -382,6 +385,22 @@ describe('IonCore', function () {
               SENT_PING.keyId,
               sinon.match(SENT_PING.key)
             ).calledOnce
+      );
+    });
+  });
+
+  describe('_handleWebMessage()', function () {
+    it('rejects unknown websites', function () {
+      assert.rejects(
+        this.ionCore._handleWebMessage({}, {url: "https://unknown.example.com"}),
+        { message: "IonCore - received message from unexpected URL https://unknown.example.com"}
+      );
+    });
+
+    it('rejects unknown addon ids', function () {
+      assert.rejects(
+        this.ionCore._handleWebMessage({}, {url: FAKE_WEBSITE, id: "unknown-test-id"}),
+        { message: "IonCore - received message from an unexpected webextension unknown-test-id"}
       );
     });
   });


### PR DESCRIPTION
Fixes #103 

This adds the required background and content script features in order to make the core addon communicate with the platform website.
