### PR TITLE
adds onboarding flow directly into the Core Add-On

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,9 @@
 /public/build/
 /public/fonts/
 
+# Hide stylesheets moved from node_modules to
+# this directory to be served directly
+public/protocol-extra.css
+public/protocol.css
+
 .DS_Store

--- a/public/index.html
+++ b/public/index.html
@@ -7,10 +7,6 @@
     <title>Ion: Put your data to work for a better internet</title>
 
     <link rel="icon" type="image/png" href="favicon.svg" />
-    <!-- <link rel="stylesheet" href="common.css" />
-    <link rel="stylesheet" href="pioneer.css" />
-    <link rel="stylesheet" href="global.css" /> -->
-
     <link rel="stylesheet" href="build/bundle.css" />
 
     <script defer src="build/bundle.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -7,9 +7,9 @@
     <title>Ion: Put your data to work for a better internet</title>
 
     <link rel="icon" type="image/png" href="favicon.svg" />
-    <link rel="stylesheet" href="common.css" />
+    <!-- <link rel="stylesheet" href="common.css" />
     <link rel="stylesheet" href="pioneer.css" />
-    <link rel="stylesheet" href="global.css" />
+    <link rel="stylesheet" href="global.css" /> -->
 
     <link rel="stylesheet" href="build/bundle.css" />
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,6 @@ import commonjs from "@rollup/plugin-commonjs";
 import livereload from "rollup-plugin-livereload";
 import { terser } from "rollup-plugin-terser";
 import replace from "@rollup/plugin-replace";
-import postcss from 'rollup-plugin-postcss';
 import copy from 'rollup-plugin-copy';
 
 import STORE_MOCK from "./src/mocks/firefox-mock";

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,12 +53,11 @@ export default {
       __STORE_IMPLEMENTATION__: JSON.stringify(STORE_MOCK),
       __API_ENDPOINT__: production ? "web-extension" : "web",
     }),
-    postcss({
-      extract: 'external.css'
-    }),
     copy({
       targets: [
-        { src: 'node_modules/@mozilla-protocol/core/protocol/fonts/*', dest: 'public/fonts/'}
+        { src: 'node_modules/@mozilla-protocol/core/protocol/fonts/*', dest: 'public/fonts/'},
+        { src: 'node_modules/@mozilla-protocol/core/protocol/css/protocol.css', dest: 'public/build/'},
+        { src: 'node_modules/@mozilla-protocol/core/protocol/css/protocol-extra.css', dest: 'public/build/'}
       ]
     }),
     svelte({

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -31,7 +31,6 @@
   // set firstRun = !enrolled.
   let firstRun;
   $: if ($store && firstRun === undefined) {
-    console.log(!$store.enrolled);
     firstRun = !$store.enrolled;
   }
 </script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,7 +29,6 @@
 
   // As soon as the store has its initial value, let's
   // set firstRun = !enrolled.
-  let view;
   let firstRun;
   $: if ($store && firstRun === undefined) {
     console.log(!$store.enrolled);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,8 +3,11 @@
    * License, v. 2.0. If a copy of the MPL was not distributed with this
    * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+  import { setContext } from "svelte";
   import { fly } from "svelte/transition";
   import { store } from "./stores.js";
+
+  import Onboarding from "./routes/Onboarding.svelte";
 
   import Modal from "./components/Modal.svelte";
   import EnrollmentButton from "./EnrollmentButton.svelte";
@@ -12,16 +15,26 @@
 
   import StudyList from "./regions/StudyList.svelte";
 
-  import EnrollmentDisclaimer from "./copy/EnrollmentDisclaimer.svelte";
   import ValueProposition from "./copy/ValueProposition.svelte";
   import HowItWorks from "./copy/HowItWorks.svelte";
   import WhyItMatters from "./copy/WhyItMatters.svelte";
+
+  setContext("rally:store", store);
 
   let enrollModal = false;
 
   const closeModal = () => {
     enrollModal = false;
   };
+
+  // As soon as the store has its initial value, let's
+  // set firstRun = !enrolled.
+  let view;
+  let firstRun;
+  $: if ($store && firstRun === undefined) {
+    console.log(!$store.enrolled);
+    firstRun = !$store.enrolled;
+  }
 </script>
 
 <style>
@@ -34,23 +47,29 @@
   }
 </style>
 
-{#if enrollModal && !$store.enrolled}
-  <Modal on:dismiss={closeModal}>
-    <h2 slot="title">Ion Privacy Consent Notice</h2>
-    <div slot="body">
-      <EnrollmentDisclaimer />
-    </div>
-    <div slot="cta">
-      <button
-        class="primary join-button"
-        on:click={() => {
-          store.updateIonEnrollment(true);
-          enrollModal = false;
-        }}>Accept and Participate</button>
-      <button on:click={closeModal}>Close</button>
-    </div>
-  </Modal>
-{:else if enrollModal}
+<!-- workaround: set the stylesheets for the NEW experience
+until we have replaced the entire UX with the Rally UX. Until then,
+select which stylesheets to use based on the current view.
+Once we have a unified view, we should move these stylesheets
+into /public/index.html.-->
+<svelte:head>
+  {#if $store}
+    {#if firstRun}
+      <!-- set all the Rally stylesheets. -->
+      <link rel="stylesheet" href="build/protocol.css" />
+      <link rel="stylesheet" href="build/protocol-extra.css" />
+      <link rel="stylesheet" href="rally.css" />
+      <link rel="stylesheet" href="tokens.css" />
+    {:else}
+      <!-- set the current Ion stylesheets -->
+      <link rel="stylesheet" href="common.css" />
+      <link rel="stylesheet" href="pioneer.css" />
+      <link rel="stylesheet" href="global.css" />
+    {/if}
+  {/if}
+</svelte:head>
+
+{#if enrollModal}
   <Modal on:dismiss={closeModal}>
     <h2 slot="title">Are you sure you want to leave Ion?</h2>
     <div slot="body" style="min-height: 100px;">Leaving Ion. Are you sure?</div>
@@ -67,45 +86,56 @@
 {/if}
 
 {#if $store}
-  <main>
-    <header>
-      <h1>Put your data to work for a better internet</h1>
-      <EnrollmentButton
-        enrolled={$store.enrolled}
-        on:click={() => {
-          // go through the join flow.
-          enrollModal = true;
-        }} />
-    </header>
+  {#if firstRun}
+    <!-- onboarding flow -->
+    <!-- the onboarding-complete event occurs once the user has
+    gotten through the profile completion step. -->
+    <Onboarding
+      on:onboarding-complete={() => {
+        firstRun = false;
+      }} />
+  {:else}
+    <!-- main application flow -->
+    <main>
+      <header>
+        <h1>Put your data to work for a better internet</h1>
+        <EnrollmentButton
+          enrolled={$store.enrolled}
+          on:click={() => {
+            // go through the join flow.
+            enrollModal = true;
+          }} />
+      </header>
 
-    <div>
-      <ValueProposition />
-    </div>
-
-    {#if $store.enrolled}
-      <div in:fly={{ duration: 250, y: 5 }}>
-        <Accordion>
-          <span slot="title">How it Works</span>
-          <div slot="content">
-            <HowItWorks />
-          </div>
-        </Accordion>
-        <Accordion>
-          <span slot="title">Your data: why it matters and how we protect it</span>
-          <div slot="content">
-            <WhyItMatters />
-          </div>
-        </Accordion>
+      <div>
+        <ValueProposition />
       </div>
-    {:else}
-      <h2>How it Works</h2>
-      <HowItWorks />
-      <h2>Your data: why it matters and how we protect it</h2>
-      <WhyItMatters />
-    {/if}
 
-    {#if $store.availableStudies}
-      <StudyList />
-    {/if}
-  </main>
+      {#if $store.enrolled}
+        <div in:fly={{ duration: 250, y: 5 }}>
+          <Accordion>
+            <span slot="title">How it Works</span>
+            <div slot="content">
+              <HowItWorks />
+            </div>
+          </Accordion>
+          <Accordion>
+            <span slot="title">Your data: why it matters and how we protect it</span>
+            <div slot="content">
+              <WhyItMatters />
+            </div>
+          </Accordion>
+        </div>
+      {:else}
+        <h2>How it Works</h2>
+        <HowItWorks />
+        <h2>Your data: why it matters and how we protect it</h2>
+        <WhyItMatters />
+      {/if}
+
+      {#if $store.availableStudies}
+        <StudyList />
+      {/if}
+    </main>
+  {/if}
 {/if}

--- a/src/routes/Onboarding.svelte
+++ b/src/routes/Onboarding.svelte
@@ -1,4 +1,7 @@
 <script>
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
   import { onMount, getContext, createEventDispatcher } from "svelte";
   import Layout from "../components/Layout.svelte";
   import Main from "../components/Main.svelte";

--- a/src/routes/Onboarding.svelte
+++ b/src/routes/Onboarding.svelte
@@ -1,0 +1,81 @@
+<script>
+  import { onMount, getContext, createEventDispatcher } from "svelte";
+  import Layout from "../components/Layout.svelte";
+  import Main from "../components/Main.svelte";
+  import Welcome from "../routes/welcome/Content.svelte";
+  import Demographics from "./demographics/Content.svelte";
+  import TermsOfService from "./terms-of-service/Content.svelte";
+  import OnboardingCTAContainer from "../components/OnboardingCTAContainer.svelte";
+
+  import DemographicsCallToAction from "./demographics/CallToAction.svelte";
+  import TermsCallToAction from "./terms-of-service/CallToAction.svelte";
+
+  export let view = "welcome";
+  let mounted = false;
+
+  const store = getContext("rally:store");
+
+  const dispatch = createEventDispatcher();
+
+  onMount(() => {
+    mounted = true;
+  });
+
+  function send(next) {
+    view = next;
+    window.scrollTo(0, 0);
+  }
+
+  function step(w) {
+    if (w === "welcome") return 1;
+    if (w === "terms") return 2;
+    if (w === "demographics") return 3;
+    return 1;
+  }
+
+  function finishOnboarding() {
+    dispatch("onboarding-complete");
+  }
+
+  let results;
+</script>
+
+{#if mounted}
+  <div>
+    <Layout>
+      <Main padForOnboarding={view !== 'welcome'}>
+        {#if view === 'welcome'}
+          <Welcome on:get-started={() => send('terms')} />
+        {:else if view === 'terms'}
+          <TermsOfService />
+        {:else if view === 'demographics'}
+          <Demographics bind:results />
+        {/if}
+      </Main>
+      <OnboardingCTAContainer
+        step={step(view)}
+        transparent={view === 'welcome'}>
+        {#if view === 'terms'}
+          <TermsCallToAction
+            on:accept={() => {
+              // Join Rally.
+              store.updateIonEnrollment(true);
+              send('demographics');
+            }}
+            on:cancel={() => {
+              send('welcome');
+            }} />
+        {:else if view === 'demographics'}
+          <DemographicsCallToAction
+            on:save={() => {
+              // Submit Demographics here.
+              // store.updateDemographicSurvey(results)
+              // move to the main view.
+              finishOnboarding();
+            }}
+            on:skip={finishOnboarding} />
+        {/if}
+      </OnboardingCTAContainer>
+    </Layout>
+  </div>
+{/if}

--- a/src/routes/demographics/Content.svelte
+++ b/src/routes/demographics/Content.svelte
@@ -62,7 +62,7 @@
     age: {
       key: "age",
       label: "1. What is your age?",
-      type: "multi",
+      type: "single",
       columns: true,
       values: [
         { key: "19-24", label: "19-24 years old" },


### PR DESCRIPTION
closes #102 

This implements JUST the onboarding flow for the Core Add-On. Once we get past the onboarding step, it will do an ugly flicker while the stylesheets change back to the regular Ion-style card display.

This does _not_ submit the demographic survey nor does it save it in the add-on's storage. I have the basic storage schema directly in the [Demographics container component (take a look at this link)](https://github.com/mozilla-ion/ion-core-addon/blob/master/src/routes/demographics/Content.svelte#L57). This should be migrated outside of the component then imported into it in some way.

@Dexterp37 is this enough of a starting point to contribute to handling the demographic survey in storage / submitting it (#124)?