### PR TITLE
Store the demographics survey data and send the related ping

### DIFF
--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -191,25 +191,16 @@ module.exports = class DataCollection {
 
     // Map all the fields but "race" (because that has multiple
     // possible values).
-    for (let originalField in FIELD_MAPPING) {
+    for (const [originalField, newName] of Object.entries(FIELD_MAPPING)) {
       if (originalField in data) {
-        const newName = FIELD_MAPPING[originalField];
-        if (!(newName in processed)) {
-          processed[newName] = {};
-        }
-        processed[newName][data[originalField]] = true;
+        processed[newName] = { [data[originalField]]: true };
       }
     }
 
     // Note: "race" gets renamed to "races" and has multiple
     // values.
     if ("race" in data) {
-      for (let race of data["race"]) {
-        if (!("races" in processed)) {
-          processed["races"] = {};
-        }
-        processed["races"][race] = true;
-      }
+      processed["races"] = data.race.reduce((a, b) => ((a[b] = true), a), {});
     }
 
     return await this.sendPing(

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -566,5 +566,7 @@ module.exports = class IonCore {
   async _updateDemographics(data) {
     await this._storage.setItem("demographicsData", data)
       .catch(e => console.error(`IonCore._updateDemographics - failed to save data`, e));
+
+    return await this._dataCollection.sendDemographicSurveyPing(data);
   }
 }

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -190,6 +190,8 @@ module.exports = class IonCore {
       case "unenrollment":
         return this._unenroll()
                    .then(r => this._sendStateUpdateToUI());
+      case "update-demographics":
+        return this._updateDemographics(message.data);
       default:
         return Promise.reject(
           new Error(`IonCore - unexpected message type ${message.type}`));
@@ -549,5 +551,20 @@ module.exports = class IonCore {
     // Send a message to the UI to update the list of studies.
     this._connectionPort.postMessage(
       {type: "update-state", data: newState});
+  }
+
+  /**
+   * Updates the stored version of the demographics data.
+   *
+   * After the locally stored data is updated, the recent data
+   * is sent to the pipeline.
+   *
+   * @param {Object} data
+   *        A JSON-serializable object containing the demographics
+   *        information submitted by the user.
+   */
+  async _updateDemographics(data) {
+    await this._storage.setItem("demographicsData", data)
+      .catch(e => console.error(`IonCore._updateDemographics - failed to save data`, e));
   }
 }

--- a/docs/DATA_COLLECTION.md
+++ b/docs/DATA_COLLECTION.md
@@ -1,0 +1,103 @@
+# Data Documentation
+This describes the data being collected and sent by the Core Add-on out of the box.
+This add-on will send a [`pioneer-study` pings](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/pioneer-study.html) with a different encrypted payload using the Ion platform, through Firefox, in different circumstances:
+
+- when [joining the platform](#joining-the-platform-pioneer-enrollment);
+- when [joining a study](#joining-a-study-pioneer-enrollment);
+- when filling the [demographics survey](#filling-the-demographic-survey-demographic-survey);
+- when [leaving a study](#leaving-a-study-deletion-request).
+- when [leaving the platform](#leaving-the-platform);
+
+## Joining the platform: `pioneer-enrollment`
+A [`pioneer-study` ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/pioneer-study.html) with [an empty `encryptedData` field](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/templates/include/pioneer-study/pioneer-enrollment.1.schema.json) is sent when user joins the platform.
+
+```json
+  "payload": {
+    "encryptedData": "<encrypted token>",
+    "schemaVersion": 1,
+    "schemaName": "pioneer-enrollment",
+    "schemaNamespace": "pioneer-core",
+    "encryptionKeyId": "core",
+    "pioneerId": "<UUID>",
+    "studyName": "pioneer-core"
+  }
+```
+
+## Joining a study: `pioneer-enrollment`
+After a user joins the platform, studies can be joined, too. A [`pioneer-study` ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/pioneer-study.html) with [an empty `encryptedData` field](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/templates/include/pioneer-study/pioneer-enrollment.1.schema.json) is sent when user clicks the Join button for a study and accepts the study policy.
+
+```json
+  "payload": {
+    "encryptedData": "<encrypted token>",
+    "schemaVersion": 1,
+    "schemaName": "pioneer-enrollment",
+    "schemaNamespace": "<study-id>",
+    "encryptionKeyId": "discarded",
+    "pioneerId": "<UUID>",
+    "studyName": "<study-id>"
+  }
+```
+
+> **Important:** the `payload.encryptionKeyId` is set to `discarded` because the `payload.encryptedData` is an empty object, but still encrypted.
+
+## Filling the demographic survey: `demographic-survey`
+After a user joins the platform they are asked to fill a demographic survey, in order to help researchers parse the data. The survey is optional and can be partially filled. A [`pioneer-study` ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/pioneer-study.html) with [the `survey` payload](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/templates/include/pioneer-study/survey.1.schema.json) is sent when user submits the survey.
+
+This is an example of the data that will be sent in the `encryptedData` field:
+
+```json
+{
+  "age": {
+    "19_24": true
+  },
+  "gender": {
+    "decline": true
+  },
+  "origin": {
+    "other": true
+  },
+  "races": {
+    "japanese": true,
+    "filipino": true
+  },
+  "education": {
+    "lessThanHighSchool": true
+  },
+  "income": {
+    "0_24999": true
+  },
+  "zipCode": "00123"
+}
+```
+
+All the sections in this encrypted payload are optional and some of them can contain multiple values, as described below.
+
+- `age`: the age-group of the user.
+- `gender`: the gender of the user.
+- `origin`: whether or not user is of Hispanic, Latino, Spanish or other origin (if `hispanicLatinoSpanish` is `true`); if `other` in this section is `true`, then user is neither of Hispanic, Latino or Spanish origins.
+- `race`: the races user identifies with; this can contain multiple entries.
+- `education`: the user education level.
+- `income`: the income-group of the user.
+- `zipCode`: the user's zip code.
+
+> **Important:** this payload uses the `core` value for `payload.encryptionKeyId`, since these pings are routed to the `pioneer-core` environment.
+
+## Leaving a study: `deletion-request`
+When user leaves a study, a [`pioneer-study` ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/pioneer-study.html) with [an empty `encryptedData` field](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/templates/include/pioneer-study/deletion-request.1.schema.json) is sent.
+
+```json
+  "payload": {
+    "encryptedData": "<encrypted token>",
+    "schemaVersion": 1,
+    "schemaName": "deletion-request",
+    "schemaNamespace": "<study-id>",
+    "encryptionKeyId": "discarded",
+    "pioneerId": "<UUID>",
+    "studyName": "<study-id>"
+  }
+```
+
+> **Important:** the `payload.encryptionKeyId` is set to `discarded` because the `payload.encryptedData` is an empty object, but still encrypted.
+
+## Leaving the platform
+When user choses to leave the platform by clicking on the related button in the Core Add-on options page, a [`deletion-request`](#leaving-a-study-deletion-request) is sent for each study user ever joined.

--- a/src/api/web-extension.js
+++ b/src/api/web-extension.js
@@ -26,6 +26,7 @@ async function sendToCore(port, type, payload) {
     "study-enrollment",
     "study-unenrollment",
     "unenrollment",
+    "update-demographics",
   ];
 
   // Make sure `type` is one of the expected values.
@@ -172,6 +173,17 @@ export default {
       this._connectionPort, enroll ? "enrollment" : "unenrollment", {});
 
     return true;
+  },
+
+  /**
+   * Updates the stored version of the demographics data.
+   *
+   * @param {Object} data
+   *        A JSON-serializable object containing the demographics
+   *        information submitted by the user.
+   */
+  async updateDemographicSurvey(data) {
+    await sendToCore(this._connectionPort, "update-demographics", data);
   },
 
   /**

--- a/src/create-store.js
+++ b/src/create-store.js
@@ -49,5 +49,12 @@ export default function createStore(initialState, api) {
         console.error(err);
       }
     },
+    async updateDemographicSurvey(data) {
+      try {
+        await api.updateDemographicSurvey(data);
+      } catch (err) {
+        console.error(`Ion - failed to update the demographic survey`, err);
+      }
+    }
   };
 }

--- a/src/routes/Onboarding.svelte
+++ b/src/routes/Onboarding.svelte
@@ -72,7 +72,7 @@
           <DemographicsCallToAction
             on:save={() => {
               // Submit Demographics here.
-              // store.updateDemographicSurvey(results)
+              store.updateDemographicSurvey(results);
               // move to the main view.
               finishOnboarding();
             }}

--- a/src/routes/demographics/Content.svelte
+++ b/src/routes/demographics/Content.svelte
@@ -65,12 +65,12 @@
       type: "single",
       columns: true,
       values: [
-        { key: "19-24", label: "19-24 years old" },
-        { key: "25-34", label: "25-34 years old" },
-        { key: "35-44", label: "35-44 years old" },
-        { key: "45-54", label: "45-54 years old" },
-        { key: "55-64", label: "55-64 years old" },
-        { key: "> 65", label: "65 years and older" },
+        { key: "19_24", label: "19-24 years old" },
+        { key: "25_34", label: "25-34 years old" },
+        { key: "35_44", label: "35-44 years old" },
+        { key: "45_54", label: "45-54 years old" },
+        { key: "55_64", label: "55-64 years old" },
+        { key: "over_65", label: "65 years and older" },
       ],
     },
     gender: {
@@ -90,8 +90,8 @@
       label: "3. Are you of Hispanic, Latino, or Spanish origin?",
       type: "single",
       values: [
-        { key: "no", label: "No, not of Hispanic, Latino, or Spanish origin" },
-        { key: "yes", label: "Yes" },
+        { key: "other", label: "No, not of Hispanic, Latino, or Spanish origin" },
+        { key: "hispanicLatinoSpanish", label: "Yes" },
       ],
     },
     race: {
@@ -160,12 +160,12 @@
       type: "single",
       columns: 3,
       values: [
-        { key: "0-24999", label: "$0 - $24,999" },
-        { key: "25000-49999", label: "$25,000 - $49,999" },
-        { key: "50000-74999", label: "50,000 - $74,999" },
-        { key: "75000-99999", label: "$75,000 - $99,999" },
-        { key: "100000-149999", label: "$100,000 - $149,999" },
-        { key: ">= 150000", label: "$150,000 or more" },
+        { key: "0_24999", label: "$0 - $24,999" },
+        { key: "25000_49999", label: "$25,000 - $49,999" },
+        { key: "50000_74999", label: "50,000 - $74,999" },
+        { key: "75000_99999", label: "$75,000 - $99,999" },
+        { key: "100000_149999", label: "$100,000 - $149,999" },
+        { key: "ge_150000", label: "$150,000 or more" },
       ],
     },
     zipcode: {

--- a/tests/core-addon/DataCollection.test.js
+++ b/tests/core-addon/DataCollection.test.js
@@ -112,6 +112,137 @@ describe('DataCollection', function () {
     });
   });
 
+  describe('sendDemographicSurveyPing()', function () {
+    it('generates an empty demographic-survey ping for the platform', async function () {
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.firefoxPrivilegedApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        clearIonID: async function() {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
+
+      // Since no option is mandatory, try to send an empty payload.
+      await this.dataCollection.sendDemographicSurveyPing({});
+
+      // We expect to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... an empty payload ...
+      assert.equal(Object.keys(submitArgs[1]).length, 0);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, "pioneer-core");
+      assert.equal(submitArgs[2].encryptionKeyId, "core");
+      assert.equal(submitArgs[2].schemaName, "demographic-survey");
+      assert.equal(submitArgs[2].schemaNamespace, "pioneer-core");
+    });
+
+    it('submits demographic-survey ping if unknown keys are provided', async function () {
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.firefoxPrivilegedApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        clearIonID: async function() {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
+
+      // Attempt to send some unexpected data: the collection mechanism
+      // should filter them out.
+      await this.dataCollection.sendDemographicSurveyPing({
+        "thisIsNotKnowAndNotExpected": ["wow"]
+      });
+
+      // We expect to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... an empty payload ...
+      assert.equal(Object.keys(submitArgs[1]).length, 0);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, "pioneer-core");
+      assert.equal(submitArgs[2].encryptionKeyId, "core");
+      assert.equal(submitArgs[2].schemaName, "demographic-survey");
+      assert.equal(submitArgs[2].schemaNamespace, "pioneer-core");
+    });
+
+    it('submits demographic-survey ping with partial data', async function () {
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.firefoxPrivilegedApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        clearIonID: async function() {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
+
+      // Only send one value.
+      await this.dataCollection.sendDemographicSurveyPing({
+        "age": "35_44",
+      });
+
+      // We expect to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... with the "age" data ...
+      assert.equal(Object.keys(submitArgs[1]).length, 1);
+      assert.ok("age" in submitArgs[1]);
+      assert.equal(true, submitArgs[1]["age"]["35_44"]);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, "pioneer-core");
+      assert.equal(submitArgs[2].encryptionKeyId, "core");
+      assert.equal(submitArgs[2].schemaName, "demographic-survey");
+      assert.equal(submitArgs[2].schemaNamespace, "pioneer-core");
+    });
+
+    it('submits demographic-survey ping with races data', async function () {
+      // Create a mock for the telemetry API.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      chrome.firefoxPrivilegedApi = {
+        generateUUID: async function() { return FAKE_UUID; },
+        setIonID: async function(uuid) {},
+        clearIonID: async function() {},
+        submitEncryptedPing: async function(type, payload, options) {},
+      };
+
+      // Use the spy to record the arguments of submitEncryptedPing.
+      let telemetrySpy =
+        sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
+
+      // Only send one value.
+      await this.dataCollection.sendDemographicSurveyPing({
+        "age": "35_44",
+        "race": ["american_indian_or_alaska_native", "samoan"],
+      });
+
+      // We expect to submit a ping with the expected type ...
+      const submitArgs = telemetrySpy.getCall(0).args;
+      assert.equal(submitArgs[0], "pioneer-study");
+      // ... with the "age" and "races" ...
+      assert.equal(Object.keys(submitArgs[1]).length, 2);
+      assert.ok("races" in submitArgs[1]);
+      assert.equal(true, submitArgs[1]["races"]["american_indian_or_alaska_native"]);
+      assert.equal(true, submitArgs[1]["races"]["samoan"]);
+      // ... and a specific set of options.
+      assert.equal(submitArgs[2].studyName, "pioneer-core");
+      assert.equal(submitArgs[2].encryptionKeyId, "core");
+      assert.equal(submitArgs[2].schemaName, "demographic-survey");
+      assert.equal(submitArgs[2].schemaNamespace, "pioneer-core");
+    });
+  });
+
   afterEach(function () {
     chrome.flush();
   });

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -483,6 +483,20 @@ describe('IonCore', function () {
     });
   });
 
+  describe('_updateDemographics()', function () {
+    it('properly saves data to the local storage', async function () {
+      let TEST_SURVEY_DATA = { "someKey": "testValue" };
+
+      await this.ionCore._updateDemographics(TEST_SURVEY_DATA);
+
+      assert.ok(
+        browser.storage.local.set.withArgs(
+          sinon.match({"demographicsData": TEST_SURVEY_DATA})
+        ).calledOnce
+      );
+    });
+  });
+
   afterEach(function () {
     delete global.fetch;
     chrome.flush();


### PR DESCRIPTION
Fixes #124

It stores the survey data in the core addon and defines a ping to send out.

**Important**: the schema will be deployed in #182.

Todo:

- [x] Write unit tests.
- [x] Design the survey ping and send it.
- [x] Get encryption keys for the pioneer-meta table.
- [x] Document the new ping.
- [x] ~~Deploy the new ping schema.~~