### PR TITLE
Create `rally.js`

### DIFF
--- a/support/README.md
+++ b/support/README.md
@@ -1,0 +1,5 @@
+# Rally.js
+
+This is the Rally partner support library, `Rally.js`, used to manage the lifecycle of Rally studies.
+
+This library is used in the [Rally Study Template](https://github.com/mozilla-ion/ion-basic-study).

--- a/support/package-lock.json
+++ b/support/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@mozilla/rally",
+  "version": "0.0.1",
+  "lockfileVersion": 1
+}

--- a/support/package-lock.json
+++ b/support/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@mozilla/rally",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1
 }

--- a/support/package.json
+++ b/support/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@mozilla/rally",
+  "version": "0.0.1",
+  "scripts": {},
+  "devDependencies": {},
+  "dependencies": {},
+  "description": "The Rally partner support library.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mozilla-ion/ion-core-addon.git",
+    "directory": "support"
+  },
+  "keywords": [],
+  "author": "Mozilla Rally team",
+  "license": "MPL-2.0",
+  "bugs": {
+    "url": "https://github.com/mozilla-ion/ion-core-addon/issues"
+  },
+  "homepage": "https://github.com/mozilla-ion/ion-core-addon#readme"
+}

--- a/support/package.json
+++ b/support/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@mozilla/rally",
-  "version": "0.0.1",
+  "version": "0.0.2",
+  "description": "The Rally partner support library.",
+  "main": "rally.js",
   "scripts": {},
   "devDependencies": {},
   "dependencies": {},
-  "description": "The Rally partner support library.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mozilla-ion/ion-core-addon.git",

--- a/support/rally.js
+++ b/support/rally.js
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+const CORE_ADDON_ID = "ion-core-addon@mozilla.org";
+const ION_SIGNUP_URL = "https://mozilla-ion.github.io/ion-core-addon/";
+
+module.exports = class Ion {
+  /**
+   * Initialize the Ion library.
+   *
+   * @param {String} keyId
+   *        The id of the key used to encrypt outgoing data.
+   * @param {Object} key
+   *        The JSON Web Key (JWK) used to encrypt the outgoing data.
+   *        See the RFC 7517 https://tools.ietf.org/html/rfc7517
+   *        for additional information. For example:
+   *
+   *        {
+   *          "kty":"EC",
+   *          "crv":"P-256",
+   *          "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+   *          "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+   *          "kid":"Public key used in JWS spec Appendix A.3 example"
+   *        }
+   */
+  async initialize(keyId, key) {
+    console.debug("Ion.initialize");
+
+    this._validateEncryptionKey(keyId, key);
+
+    this._keyId = keyId;
+    this._key = key;
+
+    await this._checkIonCore().then(
+        () => console.debug("Ion.initialize - Found Ion Core")
+      ).catch(
+        async () => await browser.tabs.create({ url: ION_SIGNUP_URL })
+      );
+
+    // Listen for incoming messages from the Core addon.
+    browser.runtime.onMessageExternal.addListener(
+      (m, s) => this._handleExternalMessage(m, s));
+
+    // We went through the whole init process, it's now safe
+    // to use the Ion public APIs.
+    this._initialized = true;
+  }
+
+  /**
+   * Check if the Core addon is installed.
+   *
+   * @returns {Promise} resolved if the core addon was found and
+   *          communication was successful, rejected otherwise.
+   */
+  async _checkIonCore() {
+    try {
+      return await browser.management.get(CORE_ADDON_ID);
+    } catch (ex) {
+      console.error("Ion._checkIonCore - core addon not found", ex);
+      return Promise.reject(ex);
+    }
+
+    // TODO: in addition to checking if the addon is installed,
+    // this should check if user has joined the platform by sending
+    // a message to the addon and waiting for its response.
+  }
+
+  /**
+   * Handles messages coming in from external addons.
+   *
+   * @param {Object} message
+   *        The payload of the message.
+   * @param {runtime.MessageSender} sender
+   *        An object containing informations about who sent
+   *        the message.
+   * @returns {Promise} The response to the received message.
+   *          It can be resolved with a value that is sent to the
+   *          `sender`.
+   */
+  _handleExternalMessage(message, sender) {
+    // We only expect messages coming from the core addon.
+    if (sender.id != CORE_ADDON_ID) {
+      return Promise.reject(
+        new Error(`Ion._handleExternalMessage - unexpected sender ${sender.id}`));
+    }
+
+    switch (message.type) {
+      case "uninstall":
+        return browser.management.uninstallSelf({showConfirmDialog: false});
+      default:
+        return Promise.reject(
+          new Error(`Ion._handleExternalMessage - unexpected message type ${message.type}`));
+    }
+  }
+
+  /**
+   * Validate the provided encryption keys.
+   *
+   * @param {String} keyId
+   *        The id of the key used to encrypt outgoing data.
+   * @param {Object} key
+   *        The JSON Web Key (JWK) used to encrypt the outgoing data.
+   *        See the RFC 7517 https://tools.ietf.org/html/rfc7517
+   *        for additional information. For example:
+   *
+   *        {
+   *          "kty":"EC",
+   *          "crv":"P-256",
+   *          "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+   *          "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+   *          "kid":"Public key used in JWS spec Appendix A.3 example"
+   *        }
+   *
+   * @throws {Error} if either the key id or the JWK key object are
+   *         invalid.
+   */
+  _validateEncryptionKey(keyId, key) {
+    if (typeof keyId !== "string") {
+      throw new Error(`Ion._validateEncryptionKey - Invalid encryption key id ${keyId}`);
+    }
+
+    if (typeof key !== "object") {
+      throw new Error(`Ion._validateEncryptionKey - Invalid encryption key ${key}`);
+    }
+  }
+
+  /**
+   * Submit an encrypted ping through the Ion Core addon.
+   *
+   * @param {String} payloadType
+   *        The type of the encrypted payload. This will define the
+   *        `schemaName` of the ping.
+   * @param {Object} payload
+   *        A JSON-serializable payload to be sent with the ping.
+   */
+  async sendPing(payloadType, payload) {
+    if (!this._initialized) {
+      console.error("Ion.sendPing - Not initialzed, call `initialize()`");
+      return;
+    }
+
+    // Wrap everything in a try block, as we don't really want
+    // data collection to be the culprit of a bug hindering user
+    // experience.
+    try {
+      // The unique identifier of the study can be used as the
+      // namespace, in order to make sure data is routed to the
+      // proper analysis sandbox.
+      const studyName = browser.runtime.id;
+
+      // This function may be mistakenly called while init has not
+      // finished. Let's be safe and check for key validity again.
+      this._validateEncryptionKey(this._keyId, this._key);
+
+      const msg = {
+        type: "telemetry-ping",
+        data: {
+          payloadType: payloadType,
+          payload: payload,
+          namespace: studyName,
+          keyId: this._keyId,
+          key: this._key
+        }
+      }
+      await browser.runtime.sendMessage(CORE_ADDON_ID, msg, {});
+    } catch (ex) {
+      console.error(`Ion.sendPing - error while sending ${payloadType}`, ex);
+    }
+  }
+}

--- a/support/rally.js
+++ b/support/rally.js
@@ -5,9 +5,9 @@
 const CORE_ADDON_ID = "ion-core-addon@mozilla.org";
 const ION_SIGNUP_URL = "https://mozilla-ion.github.io/ion-core-addon/";
 
-module.exports = class Ion {
+module.exports = class Rally {
   /**
-   * Initialize the Ion library.
+   * Initialize the Rally library.
    *
    * @param {String} keyId
    *        The id of the key used to encrypt outgoing data.
@@ -25,15 +25,15 @@ module.exports = class Ion {
    *        }
    */
   async initialize(keyId, key) {
-    console.debug("Ion.initialize");
+    console.debug("Rally.initialize");
 
     this._validateEncryptionKey(keyId, key);
 
     this._keyId = keyId;
     this._key = key;
 
-    await this._checkIonCore().then(
-        () => console.debug("Ion.initialize - Found Ion Core")
+    await this._checkRallyCore().then(
+        () => console.debug("Rally.initialize - Found the Core Add-on")
       ).catch(
         async () => await browser.tabs.create({ url: ION_SIGNUP_URL })
       );
@@ -43,7 +43,7 @@ module.exports = class Ion {
       (m, s) => this._handleExternalMessage(m, s));
 
     // We went through the whole init process, it's now safe
-    // to use the Ion public APIs.
+    // to use the Rally public APIs.
     this._initialized = true;
   }
 
@@ -53,11 +53,11 @@ module.exports = class Ion {
    * @returns {Promise} resolved if the core addon was found and
    *          communication was successful, rejected otherwise.
    */
-  async _checkIonCore() {
+  async _checkRallyCore() {
     try {
       return await browser.management.get(CORE_ADDON_ID);
     } catch (ex) {
-      console.error("Ion._checkIonCore - core addon not found", ex);
+      console.error("Rally._checkRallyCore - core addon not found", ex);
       return Promise.reject(ex);
     }
 
@@ -82,7 +82,7 @@ module.exports = class Ion {
     // We only expect messages coming from the core addon.
     if (sender.id != CORE_ADDON_ID) {
       return Promise.reject(
-        new Error(`Ion._handleExternalMessage - unexpected sender ${sender.id}`));
+        new Error(`Rally._handleExternalMessage - unexpected sender ${sender.id}`));
     }
 
     switch (message.type) {
@@ -90,7 +90,7 @@ module.exports = class Ion {
         return browser.management.uninstallSelf({showConfirmDialog: false});
       default:
         return Promise.reject(
-          new Error(`Ion._handleExternalMessage - unexpected message type ${message.type}`));
+          new Error(`Rally._handleExternalMessage - unexpected message type ${message.type}`));
     }
   }
 
@@ -117,16 +117,16 @@ module.exports = class Ion {
    */
   _validateEncryptionKey(keyId, key) {
     if (typeof keyId !== "string") {
-      throw new Error(`Ion._validateEncryptionKey - Invalid encryption key id ${keyId}`);
+      throw new Error(`Rally._validateEncryptionKey - Invalid encryption key id ${keyId}`);
     }
 
     if (typeof key !== "object") {
-      throw new Error(`Ion._validateEncryptionKey - Invalid encryption key ${key}`);
+      throw new Error(`Rally._validateEncryptionKey - Invalid encryption key ${key}`);
     }
   }
 
   /**
-   * Submit an encrypted ping through the Ion Core addon.
+   * Submit an encrypted ping through the Rally Core addon.
    *
    * @param {String} payloadType
    *        The type of the encrypted payload. This will define the
@@ -136,7 +136,7 @@ module.exports = class Ion {
    */
   async sendPing(payloadType, payload) {
     if (!this._initialized) {
-      console.error("Ion.sendPing - Not initialzed, call `initialize()`");
+      console.error("Rally.sendPing - Not initialzed, call `initialize()`");
       return;
     }
 
@@ -165,7 +165,7 @@ module.exports = class Ion {
       }
       await browser.runtime.sendMessage(CORE_ADDON_ID, msg, {});
     } catch (ex) {
-      console.error(`Ion.sendPing - error while sending ${payloadType}`, ex);
+      console.error(`Rally.sendPing - error while sending ${payloadType}`, ex);
     }
   }
 }


### PR DESCRIPTION
Fixes #75 

The published package [lives here](https://www.npmjs.com/package/@mozilla/rally).

The companion PR to use this library in the study template is mozilla-ion/ion-basic-study#17

To publish an update:

```bash
> npm whoami # to make sure to be logged in
> npm login # if not logged in

# From the ion-core-addon/support directory

> npm publish --access=public 
```