### PR TITLE
Fix taskcluster ci failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-support-library": "mocha --require  \"./tests/hooks.js\" \"./tests/support/*.js\"",
     "lint-addon": "web-ext lint",
     "lint-js": "eslint . .storybook",
-    "lint": "npm-run-all lint-*",
+    "lint": "npm run build && npm-run-all lint-*",
     "lint-css": "stylelint 'public/*.css' '.storybook/*.css' 'src/**/*.svelte' 'stories/**/*.svelte'",
     "storybook": "start-storybook -p 6006 -s public/",
     "build-storybook": "build-storybook -s public/",

--- a/support/package.json
+++ b/support/package.json
@@ -4,7 +4,7 @@
   "description": "The Rally partner support library.",
   "main": "rally.js",
   "scripts": {
-    "build": "echo FIXME"
+    "build": "echo FIXME, taskcluster requires a build target."
   },
   "devDependencies": {},
   "dependencies": {},

--- a/support/package.json
+++ b/support/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.3",
   "description": "The Rally partner support library.",
   "main": "rally.js",
-  "scripts": {},
+  "scripts": {
+    "build": "echo FIXME"
+  },
   "devDependencies": {},
   "dependencies": {},
   "repository": {


### PR DESCRIPTION
This is equivalent to the PR on https://github.com/mozilla-extensions/ion-core-addon/pull/5 - note that the support library is causing us some trouble over there because the taskcluster signing automation stuff searches recursively for `package.json` files and assumes anything it finds is an extension that produces a `.xpi` :/

@hamilton I think @Dexterp37 is done with his day, would you mind taking a look so we can merge this and move signing forward for now? Thanks!