### PR TITLE
Link GitHub Pages site to 0.6.1 pre-release

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -200,7 +200,7 @@
     <a
       id="installButton"
       tabindex="0"
-      href="https://github.com/mozilla-ion/ion-core-addon/releases/download/v2.3/ion_core.xpi"
+      href="https://github.com/mozilla-ion/ion-core-addon/releases/download/v0.6.1/ion_core-0.6.1-test1.xpi"
       >Install the Ion Web Extension</a
     >
     <div id="installedBlob" style="display: none">


### PR DESCRIPTION
OK I re-did this more properly - @Dexterp37 since we don't have the signed add-on yet, I took the latest 0.6.1 release from your PR on mozilla-extensions/ion-core-addon and added it as an artifact to our corresponding GH release.

In the future we should not need to do this, we will go with the signed add-on instead. But for today I want to unbust our GH pages site in a reasonable way.