### PR TITLE
Remove reliance on the Pioneer id preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla-ion/ion-core-addon/compare/v0.6.1...main)
 
+* #237: Remove reliance on the Firefox Pioner ID pref.
+
 # v0.6.1 (2020-12-09)
 
 [Full changelog](https://github.com/mozilla-ion/ion-core-addon/compare/v0.6.0...main)

--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -18,15 +18,16 @@ module.exports = class DataCollection {
   /**
    * Sends an empty Ion ping with the provided info.
    *
+   * @param {String} rallyId
+   *        The id of the Rally platform.
    * @param {String} payloadType
    *        The type of the encrypted payload. This will define the
    *        `schemaName` of the ping.
-   *
    * @param {String} namespace
    *        The namespace to route the ping. This will define the
    *        `schemaNamespace` and `studyName` properties of the ping.
    */
-  async _sendEmptyPing(payloadType, namespace) {
+  async _sendEmptyPing(rallyId, payloadType, namespace) {
     let publicKey;
     let keyId;
 
@@ -56,6 +57,7 @@ module.exports = class DataCollection {
     }
 
     await this.sendPing(
+      rallyId,
       payloadType,
       // We expect to send an empty payload.
       {},
@@ -71,41 +73,47 @@ module.exports = class DataCollection {
    * The `creationDate` provided by the telemetry APIs will be used as the
    * timestamp for considering the user enrolled in pioneer and/or the study.
    *
+   * @param {String} rallyId
+   *        The id of the Rally platform.
    * @param {String} [studyAddonid=undefined]
    *        optional study id. It's sent in the ping, if present, to signal
    *        that user enroled in the study.
    */
-  async sendEnrollmentPing(studyAddonId) {
+  async sendEnrollmentPing(rallyId, studyAddonId) {
     // If we were provided with a study id, then this is an enrollment to a study.
     // Send the id alongside with the data and change the schema namespace to simplify
     // the work on the ingestion pipeline.
     if (studyAddonId !== undefined) {
-      return await this._sendEmptyPing("pioneer-enrollment", studyAddonId);
+      return await this._sendEmptyPing(rallyId, "pioneer-enrollment", studyAddonId);
     }
 
     // Note that the schema namespace directly informs how data is segregated after ingestion.
     // If this is an enrollment ping for the pioneer program (in contrast to the enrollment to
     // a specific study), use a meta namespace.
-    return await this._sendEmptyPing("pioneer-enrollment", "pioneer-core");
+    return await this._sendEmptyPing(rallyId, "pioneer-enrollment", "pioneer-core");
   }
 
   /**
    * Sends a Ion deletion-request ping.
    *
+   * @param {String} rallyId
+   *        The id of the Rally platform.
    * @param {String} studyAddonid
    *        It's sent in the ping to signal that user unenrolled from a study.
    */
-  async sendDeletionPing(studyAddonId) {
+  async sendDeletionPing(rallyId, studyAddonId) {
     if (studyAddonId === undefined) {
       throw new Error("IonCore - the deletion-request ping requires a study id");
     }
 
-    return await this._sendEmptyPing("deletion-request", studyAddonId);
+    return await this._sendEmptyPing(rallyId, "deletion-request", studyAddonId);
   }
 
   /**
    * Send a ping using the Firefox legacy telemetry.
    *
+   * @param {String} rallyId
+   *        The id of the Rally platform.
    * @param {String} payloadType
    *        The type of the encrypted payload. This will define the
    *        `schemaName` of the ping.
@@ -129,10 +137,15 @@ module.exports = class DataCollection {
    *          "kid":"Public key used in JWS spec Appendix A.3 example"
    *        }
    */
-  async sendPing(payloadType, payload, namespace, keyId, key) {
+  async sendPing(rallyId, payloadType, payload, namespace, keyId, key) {
+    if (!rallyId || typeof rallyId != "string") {
+      throw new Error(`DataCollection.sendPing - invalid Rally id ${rallyId}`);
+    }
+
     let options = {
       studyName: namespace,
       addPioneerId: true,
+      overridePioneerId: rallyId,
       encryptionKeyId: keyId,
       publicKey: key,
       schemaName: payloadType,
@@ -160,11 +173,13 @@ module.exports = class DataCollection {
   /**
    * Sends a demographic-survey ping.
    *
+   * @param {String} rallyId
+   *        The id of the Rally platform.
    * @param {Object} data
    *        A JSON-serializable object containing the demographics
    *        information submitted by the user..
    */
-  async sendDemographicSurveyPing(data) {
+  async sendDemographicSurveyPing(rallyId, data) {
     const FIELD_MAPPING = {
       "age": "age",
       "gender": "gender",
@@ -204,6 +219,7 @@ module.exports = class DataCollection {
     }
 
     return await this.sendPing(
+      rallyId,
       "demographic-survey",
       processed,
       "pioneer-core",

--- a/core-addon/FirefoxPrivilegedApi.js
+++ b/core-addon/FirefoxPrivilegedApi.js
@@ -4,7 +4,6 @@
 
 "use strict";
 
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const { TelemetryController } = ChromeUtils.import(
   "resource://gre/modules/TelemetryController.jsm"
 );
@@ -15,11 +14,6 @@ const { XPCOMUtils } = ChromeUtils.import(
 XPCOMUtils.defineLazyServiceGetters(this, {
   gUUIDGenerator: ["@mozilla.org/uuid-generator;1", "nsIUUIDGenerator"],
 });
-
-// The pref that contains the Ion ID within Firefox. Unfortunately
-// the telemetry APIs require this, therefore it needs to be set in
-// prefs even though it will be stored in the standard addon storage area.
-const PREF_ION_ID = "toolkit.telemetry.pioneerId";
 
 this.firefoxPrivilegedApi = class extends ExtensionAPI {
   getAPI(context) {
@@ -33,12 +27,6 @@ this.firefoxPrivilegedApi = class extends ExtensionAPI {
           augmentedOptions.useEncryption = true;
 
           TelemetryController.submitExternalPing(type, payload, options);
-        },
-        async setIonID(id) {
-          Services.prefs.setStringPref(PREF_ION_ID, id);
-        },
-        async clearIonID() {
-          Services.prefs.clearUserPref(PREF_ION_ID);
         },
         async generateUUID() {
           // eslint-disable-next-line no-undef

--- a/core-addon/FirefoxPrivilegedApi.schema.json
+++ b/core-addon/FirefoxPrivilegedApi.schema.json
@@ -56,25 +56,6 @@
         "async": true
       },
       {
-        "name": "setIonID",
-        "type": "function",
-        "description": "Saves the Ion ID in the Firefox prefs",
-        "parameters": [
-          {
-            "name": "type",
-            "type": "string"
-          }
-        ],
-        "async": true
-      },
-      {
-        "name": "clearIonID",
-        "type": "function",
-        "description": "Clears the Ion ID stored in the Firefox prefs",
-        "parameters": [],
-        "async": true
-      },
-      {
         "name": "generateUUID",
         "type": "function",
         "description": "Generate a random UUID using the Firefox APIs",

--- a/core-addon/FirefoxPrivilegedApi.schema.json
+++ b/core-addon/FirefoxPrivilegedApi.schema.json
@@ -29,6 +29,10 @@
                 "type": "boolean",
                 "description": "Whether or not the ping should contain the Pioneer ID"
               },
+              "overridePioneerId": {
+                "type": "string",
+                "description": "The ID to use instead of the one stored in the Firefox preferences"
+              },
               "encryptionKeyId": {
                 "type": "string",
                 "description": "The public key ID to use"

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -315,12 +315,6 @@ module.exports = class IonCore {
     // Store it locally for future use.
     await this._storage.setIonID(uuid);
 
-    // The telemetry API, before sending a ping, reads the
-    // ion id from a pref. It no value is set, the API will
-    // throw and nothing will be sent. This means, at enrollment,
-    // we need set the value of that required pref.
-    await browser.firefoxPrivilegedApi.setIonID(uuid);
-
     // Finally send the ping.
     await this._dataCollection.sendEnrollmentPing();
   }
@@ -415,11 +409,6 @@ module.exports = class IonCore {
 
     // Clear locally stored Ion ID.
     await this._storage.clearIonID();
-
-    // The telemetry API, before sending a ping, reads the
-    // ion id from a pref. We're good to clear this after sending
-    // the deletion pings.
-    await browser.firefoxPrivilegedApi.clearIonID();
 
     // Clear the list of studies user took part in.
     await this._storage.clearActivatedStudies();

--- a/core-addon/IonCore.js
+++ b/core-addon/IonCore.js
@@ -223,7 +223,7 @@ module.exports = class IonCore {
 
     switch (message.type) {
       case "core-check": {
-        let enrolled = !!(await this._storage.getIonID());
+        let enrolled = !!(await this._storage.getRallyID());
         return {
           type: "core-check-response",
           data: {
@@ -233,8 +233,9 @@ module.exports = class IonCore {
       }
       case "telemetry-ping": {
         const {payloadType, payload, namespace, keyId, key} = message.data;
+        let rallyId = await this._storage.getRallyID();
         return await this._dataCollection.sendPing(
-          payloadType, payload, namespace, keyId, key
+          rallyId, payloadType, payload, namespace, keyId, key
         );
       }
       default:
@@ -313,10 +314,10 @@ module.exports = class IonCore {
     const uuid = await browser.firefoxPrivilegedApi.generateUUID();
 
     // Store it locally for future use.
-    await this._storage.setIonID(uuid);
+    await this._storage.setRallyID(uuid);
 
     // Finally send the ping.
-    await this._dataCollection.sendEnrollmentPing();
+    await this._dataCollection.sendEnrollmentPing(uuid);
   }
 
   /**
@@ -339,7 +340,8 @@ module.exports = class IonCore {
     await this._storage.appendActivatedStudy(studyAddonId);
 
     // Finally send the ping.
-    await this._dataCollection.sendEnrollmentPing(studyAddonId);
+    let rallyId = await this._storage.getRallyID();
+    await this._dataCollection.sendEnrollmentPing(rallyId, studyAddonId);
   }
 
   /**
@@ -371,7 +373,9 @@ module.exports = class IonCore {
     }
 
     await this._storage.removeActivatedStudy(studyAddonId);
-    await this._dataCollection.sendDeletionPing(studyAddonId);
+
+    let rallyId = await this._storage.getRallyID();
+    await this._dataCollection.sendDeletionPing(rallyId, studyAddonId);
   }
 
   /**
@@ -399,16 +403,18 @@ module.exports = class IonCore {
       }
     }
 
+    let rallyId = await this._storage.getRallyID();
+
     // Read the list of the studies user activated throughout
     // their stay on the Ion platform and send a deletion request
     // for each of them.
     let studyList = await this._storage.getActivatedStudies();
     for (let studyId of studyList) {
-      await this._dataCollection.sendDeletionPing(studyId);
+      await this._dataCollection.sendDeletionPing(rallyId, studyId);
     }
 
     // Clear locally stored Ion ID.
-    await this._storage.clearIonID();
+    await this._storage.clearRallyID();
 
     // Clear the list of studies user took part in.
     await this._storage.clearActivatedStudies();
@@ -538,7 +544,7 @@ module.exports = class IonCore {
    * ```
    */
   async _sendStateUpdateToUI() {
-    let enrolled = !!(await this._storage.getIonID());
+    let enrolled = !!(await this._storage.getRallyID());
     let availableStudies = await this._availableStudies;
 
     const newState = {
@@ -565,6 +571,7 @@ module.exports = class IonCore {
     await this._storage.setItem("demographicsData", data)
       .catch(e => console.error(`IonCore._updateDemographics - failed to save data`, e));
 
-    return await this._dataCollection.sendDemographicSurveyPing(data);
+    let rallyId = await this._storage.getRallyID();
+    return await this._dataCollection.sendDemographicSurveyPing(rallyId, data);
   }
 }

--- a/core-addon/Storage.js
+++ b/core-addon/Storage.js
@@ -33,16 +33,16 @@ module.exports = class Storage {
     return browser.storage.local.set({ [key]: value });
   }
 
-  async getIonID() {
-    return await this.getItem("ionId");
+  async getRallyID() {
+    return await this.getItem("rallyId");
   }
 
-  async setIonID(uuid) {
-    return await this.setItem("ionId", uuid);
+  async setRallyID(uuid) {
+    return await this.setItem("rallyId", uuid);
   }
 
-  async clearIonID() {
-    return await browser.storage.local.remove("ionId");
+  async clearRallyID() {
+    return await browser.storage.local.remove("rallyId");
   }
 
   /**

--- a/tests/core-addon/DataCollection.test.js
+++ b/tests/core-addon/DataCollection.test.js
@@ -19,10 +19,7 @@ describe('DataCollection', function () {
   describe('sendEnrollmentPing()', function () {
     it('generates the correct ping for the platform', async function () {
       // Create a mock for the privileged API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
 
@@ -31,7 +28,7 @@ describe('DataCollection', function () {
         sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
 
       // Provide a valid enrollment message.
-      await this.dataCollection.sendEnrollmentPing();
+      await this.dataCollection.sendEnrollmentPing("some-rally-id");
 
       // We expect to submit a ping with the expected type ...
       const submitArgs = telemetrySpy.getCall(0).args;
@@ -39,6 +36,7 @@ describe('DataCollection', function () {
       // ... an empty payload ...
       assert.equal(Object.keys(submitArgs[1]).length, 0);
       // ... and a specific set of options.
+      assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, "pioneer-core");
       assert.equal(submitArgs[2].encryptionKeyId, "core");
       assert.equal(submitArgs[2].schemaName, "pioneer-enrollment");
@@ -47,10 +45,7 @@ describe('DataCollection', function () {
 
     it('generates the correct ping for the study', async function () {
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
 
@@ -59,7 +54,7 @@ describe('DataCollection', function () {
         sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
 
       // Provide a valid study enrollment message.
-      await this.dataCollection.sendEnrollmentPing(FAKE_STUDY_ID);
+      await this.dataCollection.sendEnrollmentPing("some-rally-id", FAKE_STUDY_ID);
 
       // We expect to submit a ping with the expected type ...
       const submitArgs = telemetrySpy.getCall(0).args;
@@ -67,6 +62,7 @@ describe('DataCollection', function () {
       // ... an empty payload ...
       assert.equal(Object.keys(submitArgs[1]).length, 0);
       // ... and a specific set of options.
+      assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, FAKE_STUDY_ID);
       assert.equal(submitArgs[2].encryptionKeyId, "discarded");
       assert.equal(submitArgs[2].schemaName, "pioneer-enrollment");
@@ -77,18 +73,14 @@ describe('DataCollection', function () {
   describe('sendDeletionPing()', function () {
     it('rejects if no study id is provided', function () {
       assert.rejects(
-        this.dataCollection.sendDeletionPing(),
+        this.dataCollection.sendDeletionPing("some-rally-id"),
         { message: "IonCore - the deletion-request ping requires a study id"}
       );
     });
 
     it('generates the deletion ping for the study', async function () {
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
-        clearIonID: async function() {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
 
@@ -97,7 +89,7 @@ describe('DataCollection', function () {
         sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
 
       // Provide a valid study enrollment message.
-      await this.dataCollection.sendDeletionPing(FAKE_STUDY_ID);
+      await this.dataCollection.sendDeletionPing("some-rally-id", FAKE_STUDY_ID);
 
       // We expect to submit a ping with the expected type ...
       const submitArgs = telemetrySpy.getCall(0).args;
@@ -105,6 +97,7 @@ describe('DataCollection', function () {
       // ... an empty payload ...
       assert.equal(Object.keys(submitArgs[1]).length, 0);
       // ... and a specific set of options.
+      assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, FAKE_STUDY_ID);
       assert.equal(submitArgs[2].encryptionKeyId, "discarded");
       assert.equal(submitArgs[2].schemaName, "deletion-request");
@@ -115,11 +108,7 @@ describe('DataCollection', function () {
   describe('sendDemographicSurveyPing()', function () {
     it('generates an empty demographic-survey ping for the platform', async function () {
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
-        clearIonID: async function() {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
 
@@ -128,7 +117,7 @@ describe('DataCollection', function () {
         sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
 
       // Since no option is mandatory, try to send an empty payload.
-      await this.dataCollection.sendDemographicSurveyPing({});
+      await this.dataCollection.sendDemographicSurveyPing("some-rally-id", {});
 
       // We expect to submit a ping with the expected type ...
       const submitArgs = telemetrySpy.getCall(0).args;
@@ -136,6 +125,7 @@ describe('DataCollection', function () {
       // ... an empty payload ...
       assert.equal(Object.keys(submitArgs[1]).length, 0);
       // ... and a specific set of options.
+      assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, "pioneer-core");
       assert.equal(submitArgs[2].encryptionKeyId, "core");
       assert.equal(submitArgs[2].schemaName, "demographic-survey");
@@ -144,11 +134,7 @@ describe('DataCollection', function () {
 
     it('submits demographic-survey ping if unknown keys are provided', async function () {
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
-        clearIonID: async function() {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
 
@@ -158,7 +144,7 @@ describe('DataCollection', function () {
 
       // Attempt to send some unexpected data: the collection mechanism
       // should filter them out.
-      await this.dataCollection.sendDemographicSurveyPing({
+      await this.dataCollection.sendDemographicSurveyPing("some-rally-id", {
         "thisIsNotKnowAndNotExpected": ["wow"]
       });
 
@@ -168,6 +154,7 @@ describe('DataCollection', function () {
       // ... an empty payload ...
       assert.equal(Object.keys(submitArgs[1]).length, 0);
       // ... and a specific set of options.
+      assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, "pioneer-core");
       assert.equal(submitArgs[2].encryptionKeyId, "core");
       assert.equal(submitArgs[2].schemaName, "demographic-survey");
@@ -176,11 +163,7 @@ describe('DataCollection', function () {
 
     it('submits demographic-survey ping with partial data', async function () {
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
-        clearIonID: async function() {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
 
@@ -189,7 +172,7 @@ describe('DataCollection', function () {
         sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
 
       // Only send one value.
-      await this.dataCollection.sendDemographicSurveyPing({
+      await this.dataCollection.sendDemographicSurveyPing("some-rally-id", {
         "age": "35_44",
       });
 
@@ -201,6 +184,7 @@ describe('DataCollection', function () {
       assert.ok("age" in submitArgs[1]);
       assert.equal(true, submitArgs[1]["age"]["35_44"]);
       // ... and a specific set of options.
+      assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, "pioneer-core");
       assert.equal(submitArgs[2].encryptionKeyId, "core");
       assert.equal(submitArgs[2].schemaName, "demographic-survey");
@@ -209,11 +193,7 @@ describe('DataCollection', function () {
 
     it('submits demographic-survey ping with races data', async function () {
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
-        clearIonID: async function() {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
 
@@ -222,7 +202,7 @@ describe('DataCollection', function () {
         sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
 
       // Only send one value.
-      await this.dataCollection.sendDemographicSurveyPing({
+      await this.dataCollection.sendDemographicSurveyPing("some-rally-id", {
         "age": "35_44",
         "race": ["american_indian_or_alaska_native", "samoan"],
       });
@@ -236,6 +216,7 @@ describe('DataCollection', function () {
       assert.equal(true, submitArgs[1]["races"]["american_indian_or_alaska_native"]);
       assert.equal(true, submitArgs[1]["races"]["samoan"]);
       // ... and a specific set of options.
+      assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, "pioneer-core");
       assert.equal(submitArgs[2].encryptionKeyId, "core");
       assert.equal(submitArgs[2].schemaName, "demographic-survey");

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -149,7 +149,6 @@ describe('IonCore', function () {
       const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
         generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
       let telemetryMock = sinon.mock(chrome.firefoxPrivilegedApi);
@@ -184,7 +183,6 @@ describe('IonCore', function () {
       const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
         generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
       let telemetryMock = sinon.mock(chrome.firefoxPrivilegedApi);
@@ -218,8 +216,6 @@ describe('IonCore', function () {
       const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
         generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
-        clearIonID: async function() {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
       let telemetryMock = sinon.mock(chrome.firefoxPrivilegedApi);
@@ -273,7 +269,6 @@ describe('IonCore', function () {
       const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
         generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
       let telemetryMock = sinon.mock(chrome.firefoxPrivilegedApi);
@@ -345,7 +340,6 @@ describe('IonCore', function () {
       const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
         generateUUID: async function() { return FAKE_UUID; },
-        setIonID: async function(uuid) {},
         submitEncryptedPing: async function(type, payload, options) {},
       };
 

--- a/tests/core-addon/IonCore.test.js
+++ b/tests/core-addon/IonCore.test.js
@@ -151,7 +151,6 @@ describe('IonCore', function () {
         generateUUID: async function() { return FAKE_UUID; },
         submitEncryptedPing: async function(type, payload, options) {},
       };
-      let telemetryMock = sinon.mock(chrome.firefoxPrivilegedApi);
 
       // Return an empty object from the local storage. Note that this
       // needs to use `browser` and must use `callsArgWith` to guarantee
@@ -162,6 +161,7 @@ describe('IonCore', function () {
       chrome.storage.local.set.yields();
 
       sinon.spy(this.ionCore._dataCollection, "sendEnrollmentPing");
+      sinon.spy(this.ionCore._storage, "setRallyID");
 
       // Provide a valid enrollment message.
       await this.ionCore._handleMessage(
@@ -169,8 +169,7 @@ describe('IonCore', function () {
       );
 
       // We expect to store the fake ion ID.
-      telemetryMock.expects("setIonID").withArgs([FAKE_UUID]).calledOnce;
-
+      assert.ok(this.ionCore._storage.setRallyID.withArgs(FAKE_UUID).calledOnce);
       assert.ok(this.ionCore._dataCollection.sendEnrollmentPing.calledOnce);
     });
 
@@ -180,30 +179,25 @@ describe('IonCore', function () {
       chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
 
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
         submitEncryptedPing: async function(type, payload, options) {},
       };
-      let telemetryMock = sinon.mock(chrome.firefoxPrivilegedApi);
 
       sinon.spy(this.ionCore._dataCollection, "sendEnrollmentPing");
 
-      // Return an empty object from the local storage. Note that this
-      // needs to use `browser` and must use `callsArgWith` to guarantee
-      // that the promise resolves, due to a bug in sinon-chrome. See
-      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
-      browser.storage.local.get.callsArgWith(1, {}).resolves();
-      chrome.storage.local.get.yields({});
+      // Mock the storage to provide a fake rally id.
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      browser.storage.local.get
+        .callsArgWith(1, {rallyId: FAKE_UUID})
+        .resolves();
+      chrome.storage.local.get.yields(FAKE_UUID);
 
       // Attempt to enroll to a study.
       await this.ionCore._enrollStudy(FAKE_STUDY_ID);
 
       // We expect to store the fake ion ID.
-      telemetryMock.expects("setIonID").withArgs([FAKE_UUID]).calledOnce;
-
       assert.ok(
-        this.ionCore._dataCollection.sendEnrollmentPing.withArgs(FAKE_STUDY_ID).calledOnce
+        this.ionCore._dataCollection.sendEnrollmentPing.withArgs(FAKE_UUID, FAKE_STUDY_ID).calledOnce
       );
     });
 
@@ -213,23 +207,21 @@ describe('IonCore', function () {
       chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
 
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
         submitEncryptedPing: async function(type, payload, options) {},
       };
-      let telemetryMock = sinon.mock(chrome.firefoxPrivilegedApi);
+
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      this.ionCore._storage = {
+        getActivatedStudies: async function() { return [FAKE_STUDY_ID]; },
+        clearActivatedStudies: async function() {},
+        getRallyID: async function() { return FAKE_UUID; },
+        clearRallyID: async function() {},
+      };
 
       sinon.spy(this.ionCore._dataCollection, "sendDeletionPing");
+      sinon.spy(this.ionCore._storage, "clearRallyID");
 
-      // Return an empty object from the local storage. Note that this
-      // needs to use `browser` and must use `callsArgWith` to guarantee
-      // that the promise resolves, due to a bug in sinon-chrome. See
-      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
-      browser.storage.local.get
-        .callsArgWith(1, {activatedStudies: [FAKE_STUDY_ID]})
-        .resolves();
-      browser.storage.local.remove.yields();
       chrome.runtime.sendMessage.yields();
       browser.management.uninstallSelf.yields();
 
@@ -238,11 +230,11 @@ describe('IonCore', function () {
         {type: "unenrollment", data: {}}
       );
 
-      // We expect to store the fake ion ID...
-      telemetryMock.expects("clearIonID").calledOnce;
+      // We expect to remove the fake rally ID...
+      assert.ok(this.ionCore._storage.clearRallyID.calledOnce);
       // ... to submit a ping with the expected type ...
       assert.ok(
-        this.ionCore._dataCollection.sendDeletionPing.withArgs(FAKE_STUDY_ID).calledOnce
+        this.ionCore._dataCollection.sendDeletionPing.withArgs(FAKE_UUID, FAKE_STUDY_ID).calledOnce
       );
       // We also expect an "uninstall" message to be dispatched to
       // the one study marked as installed.
@@ -266,23 +258,19 @@ describe('IonCore', function () {
       chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
 
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
         submitEncryptedPing: async function(type, payload, options) {},
       };
-      let telemetryMock = sinon.mock(chrome.firefoxPrivilegedApi);
+
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      this.ionCore._storage = {
+        getActivatedStudies: async function() { return [FAKE_STUDY_ID]; },
+        removeActivatedStudy: async function() {},
+        getRallyID: async function() { return FAKE_UUID; },
+      };
 
       sinon.spy(this.ionCore._dataCollection, "sendDeletionPing");
 
-      // Return an empty object from the local storage. Note that this
-      // needs to use `browser` and must use `callsArgWith` to guarantee
-      // that the promise resolves, due to a bug in sinon-chrome. See
-      // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
-      browser.storage.local.get
-        .callsArgWith(1, {activatedStudies: [FAKE_STUDY_ID]})
-        .resolves();
-      chrome.storage.local.get.yields({});
       chrome.runtime.sendMessage.yields();
 
       // Provide a valid study unenrollment message.
@@ -290,11 +278,9 @@ describe('IonCore', function () {
         {type: "study-unenrollment", data: { studyID: FAKE_STUDY_ID}}
       );
 
-      // We expect to store the fake ion ID...
-      telemetryMock.expects("setIonID").withArgs([FAKE_UUID]).calledOnce;
-      // ... to submit a ping with the expected type ...
+      // We to submit a ping with the expected type.
       assert.ok(
-        this.ionCore._dataCollection.sendDeletionPing.withArgs(FAKE_STUDY_ID).calledOnce
+        this.ionCore._dataCollection.sendDeletionPing.withArgs(FAKE_UUID, FAKE_STUDY_ID).calledOnce
       );
 
       // Make sure that we're generating an uninstall message for
@@ -337,10 +323,13 @@ describe('IonCore', function () {
 
     it('dispatches telemetry-ping messages', async function () {
       // Create a mock for the telemetry API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
         submitEncryptedPing: async function(type, payload, options) {},
+      };
+
+      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
+      this.ionCore._storage = {
+        getRallyID: async function() { return FAKE_UUID; },
       };
 
       sinon.spy(this.ionCore._dataCollection, "sendPing");
@@ -370,6 +359,7 @@ describe('IonCore', function () {
       assert.ok(
         this.ionCore._dataCollection.sendPing
             .withArgs(
+              FAKE_UUID,
               SENT_PING.payloadType,
               sinon.match(SENT_PING.payload),
               SENT_PING.namespace,
@@ -462,7 +452,10 @@ describe('IonCore', function () {
     it('properly dispatches messages to studies', async function () {
       let TEST_PAYLOAD = { "someKey": "testValue" };
 
-      // Make sure the function yields during tests!
+      // Make sure the functions yield during tests!
+      browser.storage.local.get
+        .callsArgWith(1, {activatedStudies: [FAKE_STUDY_ID]})
+        .resolves();
       chrome.runtime.sendMessage.yields();
 
       await this.ionCore._sendMessageToStudy(FAKE_STUDY_ID, "uninstall", TEST_PAYLOAD);
@@ -483,6 +476,11 @@ describe('IonCore', function () {
   describe('_updateDemographics()', function () {
     it('properly saves data to the local storage', async function () {
       let TEST_SURVEY_DATA = { "someKey": "testValue" };
+
+      // Set a fake Rally id.
+      browser.storage.local.get
+        .callsArgWith(1, {rallyId: "fake-rally-id"})
+        .resolves();
 
       await this.ionCore._updateDemographics(TEST_SURVEY_DATA);
 

--- a/tests/core-addon/integration/core_addon.js
+++ b/tests/core-addon/integration/core_addon.js
@@ -5,6 +5,11 @@
 const firefox = require("selenium-webdriver/firefox");
 const { Builder, By, until } = require("selenium-webdriver");
 
+// The number of milliseconds to wait for some
+// property to change in tests. This should be
+// a long time to account for slow CI.
+const WAIT_FOR_PROPERTY = 5000;
+
 const firefoxOptions = new firefox.Options();
 firefoxOptions.setPreference("xpinstall.signatures.required", false);
 firefoxOptions.setPreference("extensions.experiments.enabled", true);
@@ -18,6 +23,22 @@ if (process.platform === "linux") {
   firefoxOptions.setBinary(
     "/Applications/Firefox Nightly.app/Contents/MacOS/firefox"
   );
+}
+
+/**
+ * Find the element and perform an action on it.
+ *
+ * @param driver
+ *        The Selenium driver to use.
+ * @param element
+ *        The element to look for and execute actions on.
+ * @param action
+ *        A function in the form `e => {}` that will be called
+ *        and receive the element once ready.
+ */
+async function findAndAct(driver, element, action) {
+  await driver.wait(until.elementLocated(element), WAIT_FOR_PROPERTY);
+  await driver.findElement(element).then(e => action(e));
 }
 
 describe("Core-Addon Onboarding", function () {
@@ -36,13 +57,13 @@ describe("Core-Addon Onboarding", function () {
 
   it("should un/enroll in Rally", async function () {
     await this.driver.get(`file:///${__dirname}/index.html`);
-    await this.driver.wait(until.titleIs("Installation Test"), 1000);
-    await this.driver.findElement(By.id("install")).click();
+    await this.driver.wait(until.titleIs("Installation Test"), WAIT_FOR_PROPERTY);
+    await findAndAct(this.driver, By.id("install"), e => e.click());
 
     // switch to browser UI context, to interact with Firefox add-on install prompts.
     await this.driver.setContext(firefox.Context.CHROME);
-    await this.driver.findElement(By.css(`[label="Add"]`)).click();
-    await this.driver.findElement(By.css(`[label="Okay, Got It"]`)).click();
+    await findAndAct(this.driver, By.css(`[label="Add"]`), e => e.click());
+    await findAndAct(this.driver, By.css(`[label="Okay, Got It"]`), e => e.click());
 
     // Switch back to web content context.
     await this.driver.setContext(firefox.Context.CONTENT);
@@ -50,7 +71,7 @@ describe("Core-Addon Onboarding", function () {
     // We expect the extension to load its options page in a new tab.
     await this.driver.wait(async () => {
       return (await this.driver.getAllWindowHandles()).length === 2;
-    }, 1000);
+    }, WAIT_FOR_PROPERTY);
 
     // Selenium is still focused on the old tab, so switch to the new window handle.
     const newTab = (await this.driver.getAllWindowHandles())[1];
@@ -59,45 +80,30 @@ describe("Core-Addon Onboarding", function () {
     // New tab is focused.
     await this.driver.wait(
       until.titleIs("Ion: Put your data to work for a better internet"),
-      1000
+      WAIT_FOR_PROPERTY
     );
 
     await this.driver.wait(until.elementLocated(By.css("button")));
 
     // FIXME we need to use button IDs here so xpath is not needed...
     // See https://github.com/mozilla-ion/ion-core-addon/issues/244
-    await this.driver
-      .findElement(By.xpath(`//button[text()="Get Started"]`))
-      .click();
-    await this.driver
-      .findElement(By.xpath(`//button[text()="Accept & Participate"]`))
-      .click();
+    await findAndAct(this.driver, By.xpath(`//button[text()="Get Started"]`), e => e.click());
+    await findAndAct(this.driver, By.xpath(`//button[text()="Accept & Participate"]`), e => e.click());
     // TODO check that state is enrolled, see https://github.com/mozilla-ion/ion-core-addon/issues/245
 
-    await this.driver
-      .findElement(By.xpath(`//button[text()="Save & Continue"]`))
-      .click();
+    await findAndAct(this.driver, By.xpath(`//button[text()="Save & Continue"]`), e => e.click());
 
     await this.driver.wait(until.elementLocated(By.css("button")));
-    await this.driver
-      .findElement(By.xpath(`//button[text()="Join Study"]`))
-      .click();
-
-    const joinStudyConfirmSelector = `(//button[text()="Join Study"])[2]`;
-    await this.driver.wait(
-      until.elementLocated(By.xpath(joinStudyConfirmSelector)),
-      1000
-    );
-    await this.driver.findElement(By.xpath(joinStudyConfirmSelector)).click();
+    await findAndAct(this.driver, By.xpath(`//button[text()="Join Study"]`), e => e.click());
+    await findAndAct(this.driver, By.xpath(`(//button[text()="Join Study"])[2]`), e => e.click());
 
     // Switch to browser UI context, to interact with Firefox add-on install prompts.
 
     await this.driver.setContext(firefox.Context.CHROME);
-    const continueSelector = By.css(`[label="Continue to Installation"]`);
-    await this.driver.wait(until.elementLocated(continueSelector), 1000);
-    await this.driver.findElement(continueSelector).click();
-    await this.driver.findElement(By.css(`[label="Add"]`)).click();
-    await this.driver.findElement(By.css(`[label="Okay, Got It"]`)).click();
+    await findAndAct(this.driver, By.css(`[label="Continue to Installation"]`), e => e.click());
+
+    await findAndAct(this.driver, By.css(`[label="Add"]`), e => e.click());
+    await findAndAct(this.driver, By.css(`[label="Okay, Got It"]`), e => e.click());
 
     // FIXME close tab and click on icon, check that post-enrollment options page is shown.
     // This will currently fail because there is a bug in the core-addon UI, where
@@ -108,28 +114,19 @@ describe("Core-Addon Onboarding", function () {
     await this.driver.setContext(firefox.Context.CONTENT);
 
     // Begin study unenrollment cancel it.
-    const unenrollSelector = By.xpath(`//button[text()="Leave Mozilla Rally"]`);
-    const unenrollButton = await this.driver.findElement(unenrollSelector);
-    unenrollButton.click();
+    await findAndAct(this.driver, By.xpath(`//button[text()="Leave Mozilla Rally"]`), e => e.click());
 
-    const cancelSelector = By.xpath(`//button[text()="Cancel"]`);
-    await this.driver.wait(until.elementLocated(cancelSelector), 1000);
-    await this.driver.findElement(cancelSelector).click();
+    await findAndAct(this.driver, By.xpath(`//button[text()="Cancel"]`), e => e.click());
 
     // Begin unenrollment and confirm it this time.
-    await this.driver.wait(until.elementIsVisible(unenrollButton), 1000);
-    unenrollButton.click();
+    await findAndAct(this.driver, By.xpath(`//button[text()="Leave Mozilla Rally"]`), e => e.click());
 
     await this.driver.wait(
       until.titleIs("Ion: Put your data to work for a better internet"),
-      1000
+      WAIT_FOR_PROPERTY
     );
 
-    const confirmButton = await this.driver.findElement(
-      By.xpath(`//button[text()="Leave Rally"]`)
-    );
-    await this.driver.wait(until.elementIsVisible(confirmButton), 1000);
-    confirmButton.click();
+    await findAndAct(this.driver, By.xpath(`//button[text()="Leave Rally"]`), e => e.click());
     // TODO check that core add-on is uninstalled, see https://github.com/mozilla-ion/ion-core-addon/issues/245
   });
 });


### PR DESCRIPTION
Fixes #237 

This makes the Core Add-On use the new properties in Firefox Telemetry APIs available since Firefox 84.
The new property allow us to stop using the Pioneer ID preference as stored in Firefox and fully rely on the addon storage system for saving the id.

This will make it easier to reason about migrating pioneer users as well, but I intentionally left that part out of this PR.